### PR TITLE
Text input component - Change Review

### DIFF
--- a/src/components/BaseComponents/TextInput/TextInput.tsx
+++ b/src/components/BaseComponents/TextInput/TextInput.tsx
@@ -13,11 +13,17 @@ const ConditionalWrapper = ({ condition, wrapper, children }) => {
 
 export default function TextInput(props){
 
-  const {name, label, helpText, labelIsHeading, inputProps} = props;
+  const {name, label, errorText, helpText, labelIsHeading, inputProps} = props;
 
+  const formGroupDivClasses = `govuk-form-group ${errorText && 'govuk-form-group--error'}`;
+  const labelClasses = `govuk-label ${labelIsHeading?"govuk-label--l":""}`;
+
+  //TODO - Handle input widths
+  //TODO - Handle input types (password, email, numeric) - Or investigate if these should be separate components, or can simple be handled by inputProps
+  //TODO - Handle autocomplete settings
 
   return(
-    <div className="govuk-form-group">
+    <div className={formGroupDivClasses}>
       <ConditionalWrapper
         condition={labelIsHeading}
         wrapper={ children => {
@@ -27,13 +33,13 @@ export default function TextInput(props){
                   </h1>)}
                 }
         children={
-          <label className={`govuk-label ${labelIsHeading?"govuk-label--l":""}`}>{label}</label>
+            <label className={labelClasses}>{label}</label>
           }
       />
       {helpText && <div className="govuk-hint">{helpText}</div>}
+      {errorText  && <p className="govuk-error-message"><span className="govuk-visually-hidden">Error:</span>{errorText}</p> }
       <input className="govuk-input" {...inputProps} id={name} name={name}></input>
     </div>
-
   )
 }
 
@@ -42,7 +48,8 @@ TextInput.propTypes = {
   label: PropTypes.string,
   labelIsHeading: PropTypes.bool,
   inputProps: PropTypes.object,
-  helpText: PropTypes.string
+  helpText: PropTypes.string,
+  errorText: PropTypes.string
 }
 
 TextInput.defaultProps ={

--- a/src/components/BaseComponents/TextInput/TextInput.tsx
+++ b/src/components/BaseComponents/TextInput/TextInput.tsx
@@ -4,9 +4,6 @@ import PropTypes from 'prop-types';
 
 //TODO Refactor is required elsewhere
 const ConditionalWrapper = ({ condition, wrapper, children }) => {
-  console.log(condition);
-  console.log(wrapper(children));
-
   return condition ? wrapper(children) : children;
 }
 

--- a/src/components/BaseComponents/TextInput/TextInput.tsx
+++ b/src/components/BaseComponents/TextInput/TextInput.tsx
@@ -10,7 +10,7 @@ const ConditionalWrapper = ({ condition, wrapper, children }) => {
 
 export default function TextInput(props){
 
-  const {name, label, errorText, helpText, labelIsHeading, inputProps} = props;
+  const {name, label, errorText, hintText, labelIsHeading, inputProps} = props;
 
   const formGroupDivClasses = `govuk-form-group ${errorText && 'govuk-form-group--error'}`;
   const labelClasses = `govuk-label ${labelIsHeading?"govuk-label--l":""}`;
@@ -33,7 +33,7 @@ export default function TextInput(props){
             <label className={labelClasses}>{label}</label>
           }
       />
-      {helpText && <div className="govuk-hint">{helpText}</div>}
+      {hintText && <div className="govuk-hint">{hintText}</div>}
       {errorText  && <p className="govuk-error-message"><span className="govuk-visually-hidden">Error:</span>{errorText}</p> }
       <input className="govuk-input" {...inputProps} id={name} name={name}></input>
     </div>
@@ -45,7 +45,7 @@ TextInput.propTypes = {
   label: PropTypes.string,
   labelIsHeading: PropTypes.bool,
   inputProps: PropTypes.object,
-  helpText: PropTypes.string,
+  hintText: PropTypes.string,
   errorText: PropTypes.string
 }
 

--- a/src/components/BaseComponents/TextInput/TextInput.tsx
+++ b/src/components/BaseComponents/TextInput/TextInput.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+
+//TODO Refactor is required elsewhere
+const ConditionalWrapper = ({ condition, wrapper, children }) => {
+  console.log(condition);
+  console.log(wrapper(children));
+
+  return condition ? wrapper(children) : children;
+}
+
+
+export default function TextInput(props){
+
+  const {name, label, helpText, labelIsHeading, inputProps} = props;
+
+
+  return(
+    <div className="govuk-form-group">
+      <ConditionalWrapper
+        condition={labelIsHeading}
+        wrapper={ children => {
+                  return (
+                  <h1 className="govuk-label-wrapper">
+                    {children}
+                  </h1>)}
+                }
+        children={
+          <label className={`govuk-label ${labelIsHeading?"govuk-label--l":""}`}>{label}</label>
+          }
+      />
+      {helpText && <div className="govuk-hint">{helpText}</div>}
+      <input className="govuk-input" {...inputProps} id={name} name={name}></input>
+    </div>
+
+  )
+}
+
+TextInput.propTypes = {
+  name: PropTypes.string,
+  label: PropTypes.string,
+  labelIsHeading: PropTypes.bool,
+  inputProps: PropTypes.object,
+  helpText: PropTypes.string
+}
+
+TextInput.defaultProps ={
+  labelIsHeading: true,
+}

--- a/src/components/forms/Email/index.tsx
+++ b/src/components/forms/Email/index.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { TextField, InputAdornment } from '@material-ui/core';
-import MailOutlineIcon from '@material-ui/icons/MailOutline';
 import TextInput from '../TextInput';
 import FieldValueList from '../../designSystemExtensions/FieldValueList';
 
@@ -21,17 +19,6 @@ export default function Email(props) {
   } = props;
   const helperTextToDisplay = validatemessage || helperText;
 
-  if (displayMode === 'LABELS_LEFT') {
-    const field = {
-      [label]: value
-    };
-    return <FieldValueList item={field} />;
-  }
-
-  if (readOnly) {
-    return <TextInput {...props} />;
-  }
-
   let testProp = {};
 
   testProp = {
@@ -39,27 +26,15 @@ export default function Email(props) {
   };
 
   return (
-    <TextField
-      fullWidth
-      variant='outlined'
-      helperText={helperTextToDisplay}
-      placeholder=''
-      size='small'
-      required={required}
-      disabled={disabled}
-      onChange={onChange}
-      onBlur={!readOnly ? onBlur : undefined}
-      error={status === 'error'}
-      label={label}
-      value={value}
-      type='email'
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position='start'>
-            <MailOutlineIcon />
-          </InputAdornment>
-        ),
-        inputProps: { ...testProp }
+    <TextInput
+      {...props}
+      inputProps={{
+        type:'email',
+        spellcheck:"false",
+        /*
+            TODO enable if always relevant
+            autocomplete="email"
+        */
       }}
     />
   );

--- a/src/components/forms/Email/index.tsx
+++ b/src/components/forms/Email/index.tsx
@@ -30,7 +30,7 @@ export default function Email(props) {
       {...props}
       inputProps={{
         type:'email',
-        spellcheck:"false",
+        spellCheck:"false",
         /*
             TODO enable if always relevant
             autocomplete="email"

--- a/src/components/forms/Phone/index.tsx
+++ b/src/components/forms/Phone/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MuiPhoneNumber from 'material-ui-phone-number';
+import TextInput from '../TextInput';
 import FieldValueList from '../../designSystemExtensions/FieldValueList';
 
 export default function Phone(props) {
@@ -25,34 +25,10 @@ export default function Phone(props) {
     'data-test-id': testId
   };
 
-  if (displayMode === 'LABELS_LEFT') {
-    const field = {
-      [label]: value
-    };
-    return <FieldValueList item={field} />;
-  }
-
   if (readOnly) {
     const disableDropdown = true;
     return (
-      <div>
-        <MuiPhoneNumber
-          fullWidth
-          helperText={helperTextToDisplay}
-          placeholder=''
-          size='small'
-          required={required}
-          disabled={disabled}
-          onChange={onChange}
-          error={status === 'error'}
-          label={label}
-          value={value}
-          InputProps={{
-            readOnly: true
-          }}
-          disableDropdown={disableDropdown}
-        />
-      </div>
+      <></>
     );
   }
 
@@ -69,21 +45,17 @@ export default function Phone(props) {
   };
 
   return (
-    <MuiPhoneNumber
-      fullWidth
-      variant='outlined'
-      helperText={helperTextToDisplay}
-      placeholder=''
-      size='small'
-      defaultCountry='us'
-      required={required}
-      disabled={disabled}
-      onChange={handleChange}
-      onBlur={!readOnly ? handleBlur : undefined}
-      error={status === 'error'}
-      label={label}
-      value={value}
-      InputProps={{ ...testProp }}
+
+    <TextInput
+      {...props}
+      inputProps={{
+          type:'tel',
+          /*
+            TODO enable if always relevant
+            autocomplete="tel"
+          */
+        }
+      }
     />
   );
 }

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -51,15 +51,21 @@ export default function TextInput(props) {
     }
   }, [isOnlyQuestion])
 
+  let extraInputProps = {onChange, onBlur, value};
+
+  //TODO Investigate more robust way to check if we should display as password
+  if(label === "Password"){
+    extraInputProps["type"]="password";
+  }
+
   return (
     <>
     <GDSTextInput
       inputProps={{
         ...inputProps,
-        onChange,
-        onBlur,
-        value,
+        ...extraInputProps
       }}
+      hintText={helperText}
       errorText={validatemessage}
       label={displayLabel}
       labelIsHeading={isOnlyQuestion}

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -28,7 +28,7 @@ export default function TextInput(props) {
 
   const maxLength = fieldMetadata?.maxLength;
 
-  const [isOnlyQuestion, setIsOnlyQuestion] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1"));
+  const [isOnlyQuestion, setIsOnlyQuestion] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
   const [displayLabel, setDisplayLabel] = useState(label);
 
   let readOnlyProp = {}; // Note: empty if NOT ReadOnly
@@ -39,19 +39,17 @@ export default function TextInput(props) {
     'data-test-id': testId
   };
 
-  useEffect( () => {
+  useEffect ( () => {
     setIsOnlyQuestion(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
   }, [])
 
-  useEffect( () => {
+  useEffect ( () => {
     if(isOnlyQuestion){
       setDisplayLabel(getPConnect().getDataObject()?.caseInfo.assignments[0].name);
     } else {
       setDisplayLabel(label);
     }
   }, [isOnlyQuestion])
-
-  console.log(`PROPS ${JSON.stringify(props)}`);
 
   return (
     <>

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
-import { TextField } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import GDSTextInput from '../../BaseComponents/TextInput/TextInput';
 import FieldValueList from '../../designSystemExtensions/FieldValueList';
+
+
+declare const PCore;
 
 export default function TextInput(props) {
   const {
@@ -16,24 +19,19 @@ export default function TextInput(props) {
     testId,
     fieldMetadata,
     helperText,
-    displayMode
+    displayMode,
+    getPConnect,
+    inputProps,
   } = props;
+
   const helperTextToDisplay = validatemessage || helperText;
 
   const maxLength = fieldMetadata?.maxLength;
 
+  const [isOnlyQuestion, setIsOnlyQuestion] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1"));
+  const [displayLabel, setDisplayLabel] = useState(label);
+
   let readOnlyProp = {}; // Note: empty if NOT ReadOnly
-
-  if (displayMode === 'LABELS_LEFT') {
-    const field = {
-      [label]: value
-    };
-    return <FieldValueList item={field} />;
-  }
-
-  if (readOnly) {
-    readOnlyProp = { readOnly: true };
-  }
 
   let testProp = {};
 
@@ -41,21 +39,33 @@ export default function TextInput(props) {
     'data-test-id': testId
   };
 
+  useEffect( () => {
+    setIsOnlyQuestion(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
+  }, [])
+
+  useEffect( () => {
+    if(isOnlyQuestion){
+      setDisplayLabel(getPConnect().getDataObject()?.caseInfo.assignments[0].name);
+    } else {
+      setDisplayLabel(label);
+    }
+  }, [isOnlyQuestion])
+
+  console.log(`PROPS ${JSON.stringify(props)}`);
+
   return (
-    <TextField
-      fullWidth
-      variant={readOnly ? 'standard' : 'outlined'}
-      helperText={helperTextToDisplay}
-      placeholder=''
-      size='small'
-      required={required}
-      disabled={disabled}
-      onChange={onChange}
-      onBlur={!readOnly ? onBlur : undefined}
-      error={status === 'error'}
-      label={label}
-      value={value}
-      InputProps={{ ...readOnlyProp, inputProps: { maxLength, ...testProp } }}
+    <>
+    <GDSTextInput
+      inputProps={{
+        ...inputProps,
+        onChange,
+        onBlur,
+        value,
+      }}
+      errorText={validatemessage}
+      label={displayLabel}
+      labelIsHeading={isOnlyQuestion}
     />
+    </>
   );
 }


### PR DESCRIPTION
Raising PR for review -

This change adds the GDS Styled Text Input base component, which is then used by the SDK Text Input component.
Phone and Email fields have also been updated to use the SDK Text input component, passing relevant input props.

The base component can optionally wrap it's label in a `<h1>` (to comply with GDS guidance about 'single question pages'), optionally display hint and/or error text (if they are provided) 
The base component also contains a 'ConditionalWrap' helper function, which may need to be refactored out for use in other components in future.

The SDK Text Input component contains some new logic to test if there is only one editable field in this view, which in turn directs the base component to display the label as a header or not, and also updates the label to be the current step name, to mimic GDS guidance on question pages (This approach may change depending on the approach of the Pega Case)