### PR TITLE
Adds initial snapshot tests for Text Input and Select components

### DIFF
--- a/tests/unit/components/BaseComponents/Select.test.tsx
+++ b/tests/unit/components/BaseComponents/Select.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Select from '../../../../src/components/BaseComponents/Select/Select';
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(<Select></Select>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+const name = "name";
+const label = "label";
+const hintText = "hintText";
+const errorText = "errorText";
+const options = [{key:"Option_1", value:"Option 1"}, {key:"Option_2", value:"Option 2"}]
+const onChange = () => {};
+
+it('Basic single question select input', () => {
+  let a = Select.propTypes;
+
+  const tree = renderer
+    .create(<Select name={name} label={label} labelIsHeading={true} onChange={onChange}>
+      {options.map(option => {return (<option key={option.key} value={option.value}>{option.value}</option>)})}
+    </Select>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('Basic multi question select input', () => {
+  const tree = renderer
+    .create(<Select name={name} label={label} labelIsHeading={false} onChange={onChange}>
+      {options.map(option => {return (<option key={option.key} value={option.value}>{option.value}</option>)})}
+    </Select>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('Basic select input with hint and error text', () => {
+    const tree = renderer
+    .create(<Select name={name} label={label} onChange={onChange} hintText={hintText} errorText={errorText}>
+      {options.map(option => {return (<option key={option.key} value={option.value}>{option.value}</option>)})}
+    </Select>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('Basic select with pre-selected value', () => {
+  const tree = renderer
+  .create(<Select name={name} label={label} onChange={onChange} hintText={hintText} value={"Option 2"}>
+    {options.map(option => {return (<option key={option.key} value={option.value}>{option.value}</option>)})}
+  </Select>)
+  .toJSON();
+expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/components/BaseComponents/TextInput.test.tsx
+++ b/tests/unit/components/BaseComponents/TextInput.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import TextInput from '../../../../src/components/BaseComponents/TextInput/TextInput';
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(<TextInput>Facebook</TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+let name = "name";
+let label = "label";
+
+it('Basic single question text input', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={true}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('Basic single question password input', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={true} inputProps={{type:"password"}}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('Basic multi question text input', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={false}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+
+it('Basic multi question text input with error', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={false} errorText={"Something went wrong"}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+
+
+it('Basic multi question text input with hint', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={false} hintText={"Enter some text"}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+
+
+it('Basic multi question text input with hint and error', () => {
+  let a = TextInput.propTypes;
+
+  const tree = renderer
+    .create(<TextInput name={name} label={label} labelIsHeading={false} hintText={"Enter some text"} errorText={"Something went wrong"}></TextInput>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/tests/unit/components/BaseComponents/__snapshots__/Select.test.tsx.snap
+++ b/tests/unit/components/BaseComponents/__snapshots__/Select.test.tsx.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic multi question select input 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <label
+    className="govuk-label"
+    htmlFor="name"
+  >
+    label
+  </label>
+  <select
+    aria-describedby=""
+    className="govuk-select"
+    id="name"
+    name="name"
+    onChange={[Function]}
+  >
+    <option
+      value="Option 1"
+    >
+      Option 1
+    </option>
+    <option
+      value="Option 2"
+    >
+      Option 2
+    </option>
+  </select>
+</div>
+`;
+
+exports[`Basic select input with hint and error text 1`] = `
+<div
+  className="govuk-form-group govuk-form-group--error"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+      htmlFor="name"
+    >
+      label
+    </label>
+  </h1>
+  <div
+    className="govuk-hint"
+    id="name-hint"
+  >
+    hintText
+  </div>
+  <p
+    className="govuk-error-message"
+    id="name-error"
+  >
+    <span
+      className="govuk-visually-hidden"
+    >
+      Error:
+    </span>
+    errorText
+  </p>
+  <select
+    aria-describedby="name-error name-hint"
+    className="govuk-select"
+    id="name"
+    name="name"
+    onChange={[Function]}
+  >
+    <option
+      value="Option 1"
+    >
+      Option 1
+    </option>
+    <option
+      value="Option 2"
+    >
+      Option 2
+    </option>
+  </select>
+</div>
+`;
+
+exports[`Basic select with pre-selected value 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+      htmlFor="name"
+    >
+      label
+    </label>
+  </h1>
+  <div
+    className="govuk-hint"
+    id="name-hint"
+  >
+    hintText
+  </div>
+  <select
+    aria-describedby="name-hint"
+    className="govuk-select"
+    id="name"
+    name="name"
+    onChange={[Function]}
+    value="Option 2"
+  >
+    <option
+      value="Option 1"
+    >
+      Option 1
+    </option>
+    <option
+      value="Option 2"
+    >
+      Option 2
+    </option>
+  </select>
+</div>
+`;
+
+exports[`Basic single question select input 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+      htmlFor="name"
+    >
+      label
+    </label>
+  </h1>
+  <select
+    aria-describedby=""
+    className="govuk-select"
+    id="name"
+    name="name"
+    onChange={[Function]}
+  >
+    <option
+      value="Option 1"
+    >
+      Option 1
+    </option>
+    <option
+      value="Option 2"
+    >
+      Option 2
+    </option>
+  </select>
+</div>
+`;
+
+exports[`renders correctly 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+    />
+  </h1>
+  <select
+    aria-describedby=""
+    className="govuk-select"
+  />
+</div>
+`;

--- a/tests/unit/components/BaseComponents/__snapshots__/TextInput.test.tsx.snap
+++ b/tests/unit/components/BaseComponents/__snapshots__/TextInput.test.tsx.snap
@@ -1,0 +1,176 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Basic multi question text input 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <label
+    className="govuk-label"
+    htmlFor="name"
+  >
+    label
+  </label>
+  <input
+    aria-describedby=""
+    className="govuk-input"
+    id="name"
+    name="name"
+  />
+</div>
+`;
+
+exports[`Basic multi question text input with error 1`] = `
+<div
+  className="govuk-form-group govuk-form-group--error"
+>
+  <label
+    className="govuk-label"
+    htmlFor="name"
+  >
+    label
+  </label>
+  <p
+    className="govuk-error-message"
+    id="name-error"
+  >
+    <span
+      className="govuk-visually-hidden"
+    >
+      Error:
+    </span>
+    Something went wrong
+  </p>
+  <input
+    aria-describedby="name-error"
+    className="govuk-input govuk-input--error"
+    id="name"
+    name="name"
+  />
+</div>
+`;
+
+exports[`Basic multi question text input with hint 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <label
+    className="govuk-label"
+    htmlFor="name"
+  >
+    label
+  </label>
+  <div
+    className="govuk-hint"
+    id="name-hint"
+  >
+    Enter some text
+  </div>
+  <input
+    aria-describedby="name-hint"
+    className="govuk-input"
+    id="name"
+    name="name"
+  />
+</div>
+`;
+
+exports[`Basic multi question text input with hint and error 1`] = `
+<div
+  className="govuk-form-group govuk-form-group--error"
+>
+  <label
+    className="govuk-label"
+    htmlFor="name"
+  >
+    label
+  </label>
+  <div
+    className="govuk-hint"
+    id="name-hint"
+  >
+    Enter some text
+  </div>
+  <p
+    className="govuk-error-message"
+    id="name-error"
+  >
+    <span
+      className="govuk-visually-hidden"
+    >
+      Error:
+    </span>
+    Something went wrong
+  </p>
+  <input
+    aria-describedby="name-error name-hint"
+    className="govuk-input govuk-input--error"
+    id="name"
+    name="name"
+  />
+</div>
+`;
+
+exports[`Basic single question password input 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+      htmlFor="name"
+    >
+      label
+    </label>
+  </h1>
+  <input
+    aria-describedby=""
+    className="govuk-input"
+    id="name"
+    name="name"
+    type="password"
+  />
+</div>
+`;
+
+exports[`Basic single question text input 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+      htmlFor="name"
+    >
+      label
+    </label>
+  </h1>
+  <input
+    aria-describedby=""
+    className="govuk-input"
+    id="name"
+    name="name"
+  />
+</div>
+`;
+
+exports[`renders correctly 1`] = `
+<div
+  className="govuk-form-group"
+>
+  <h1
+    className="govuk-label-wrapper"
+  >
+    <label
+      className="govuk-label govuk-label--l"
+    />
+  </h1>
+  <input
+    aria-describedby=""
+    className="govuk-input"
+  />
+</div>
+`;


### PR DESCRIPTION
Adds some basic snapshot tests for sanity checking future changes to Text input and Select components

running npm run test-jest will generate 'rendered' components, and compare against the saved snapshots included with this PR.

If there are any differences, these will be highlighted in the test report. 
IF the changes are expected and required, pressing 'u' while in the test report cli interface will regenerate the snapshots, which should be included in the PR for the change.

Currently these tests will need to be run manually by developers as they are not run as part of any build steps.