### PR TITLE
BUG-5776 - Radio error fix

### DIFF
--- a/src/components/forms/RadioButtons/index.tsx
+++ b/src/components/forms/RadioButtons/index.tsx
@@ -1,6 +1,7 @@
 import React  from 'react';
 import GDSRadioButtons from '../../BaseComponents/RadioButtons/RadioButtons';
 import {useIsOnlyField, useStepName} from '../../../helpers/hooks/QuestionDisplayHooks'
+import useAddErrorToPageTitle from '../../../helpers/hooks/useAddErrorToPageTitle';
 import Utils from '../../../helpers/utils';
 
 export default function RadioButtons(props) {
@@ -21,6 +22,8 @@ export default function RadioButtons(props) {
   const isOnlyField = useIsOnlyField();
   const stepName = useStepName(isOnlyField, getPConnect);
 
+  // TODO Investigate if this can be moved to 'higher' leven in component stack to avoid repititions
+  useAddErrorToPageTitle(validatemessage);
 
   // theOptions will be an array of JSON objects that are literally key/value pairs.
   //  Ex: [ {key: "Basic", value: "Basic"} ]

--- a/src/components/forms/RadioButtons/index.tsx
+++ b/src/components/forms/RadioButtons/index.tsx
@@ -6,7 +6,9 @@ import Utils from '../../../helpers/utils';
 export default function RadioButtons(props) {
   const {
     getPConnect,
-    label
+    label,
+    validatemessage,
+    helperText
   } = props;
 
   const thePConn = getPConnect();
@@ -32,6 +34,8 @@ export default function RadioButtons(props) {
       legendIsHeading={isOnlyField}
       options={theOptions.map(option => {return {value:option.key, label:option.value}})}
       displayInline={theOptions.length === 2}
+      hintText={helperText}
+      errorText={validatemessage}
     />
   );
 }


### PR DESCRIPTION
Correctly passes hintText and ErrorText values to radio button components

(Also adds the functionality to update the page title to display error when error happens, although this will likely be over ruled by another fix to come)