### PR TITLE
BUG-5790 (and related bugs) Resolves the duplicated heading issue

### DIFF
--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 
 import AssignmentCard from '../AssignmentCard';
 import MultiStep from '../MultiStep';
+import { useIsOnlyField } from '../../helpers/hooks/QuestionDisplayHooks';
 import ErrorSummary from '../BaseComponents/ErrorSummary/ErrorSummary';
 
 declare const PCore: any;
@@ -29,6 +30,10 @@ export default function Assignment(props) {
 
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+
+
+  const isOnlyOneField = useIsOnlyField(children);
+  const containerName = thePConn.getDataObject().caseInfo.assignments[0].name
 
   function findCurrentIndicies(arStepperSteps: Array<any>, arIndicies: Array<number>, depth: number) : Array<number> {
 
@@ -208,6 +213,7 @@ export default function Assignment(props) {
       {bHasNavigation ? (
         <React.Fragment>
           <div>has Nav</div>
+          {!isOnlyOneField && <h1 className="govuk-heading-l">{containerName}</h1>}
           <MultiStep
             getPConnect={getPConnect}
             itemKey={itemKey}
@@ -222,6 +228,7 @@ export default function Assignment(props) {
         </React.Fragment>
       ) : (
         <>
+          {!isOnlyOneField && <h1 className="govuk-heading-l">{containerName}</h1>}
           <AssignmentCard
             getPConnect={getPConnect}
             itemKey={itemKey}

--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import AssignmentCard from '../AssignmentCard';
 import MultiStep from '../MultiStep';
-import { useIsOnlyField } from '../../helpers/hooks/QuestionDisplayHooks';
+import useIsOnlyField from '../../helpers/hooks/QuestionDisplayHooks';
 import ErrorSummary from '../BaseComponents/ErrorSummary/ErrorSummary';
 
 declare const PCore: any;

--- a/src/components/FlowContainer/index.tsx
+++ b/src/components/FlowContainer/index.tsx
@@ -462,19 +462,11 @@ export default function FlowContainer(props) {
               </MuiPickersUtilsProvider>
             </Card>
           ) : (
-            <div className='govuk-form-group'>
-              <fieldset className='govuk-fieldset'>
-                <legend className='govuk-fieldset__legend govuk-fieldset__legend--l'>
-                  <h1 className='govuk-fieldset__heading'>{containerName}</h1>
-                </legend>
-                {instructionText && <div className='govuk-hint'>{instructionText}</div> }
-                </fieldset>
-                <MuiPickersUtilsProvider utils={DayjsUtils}>
+            <MuiPickersUtilsProvider utils={DayjsUtils}>
                   <Assignment getPConnect={getPConnect} itemKey={itemKey}>
                     {arNewChildrenAsReact}
                   </Assignment>
-                </MuiPickersUtilsProvider>
-            </div>
+            </MuiPickersUtilsProvider>
           )
         ) : (
           <div>

--- a/src/components/forms/Dropdown/index.tsx
+++ b/src/components/forms/Dropdown/index.tsx
@@ -24,7 +24,6 @@ export default function Dropdown(props) {
 
   const [options, setOptions] = useState<Array<IOption>>([]);
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(getPConnect);
 
   const thePConn = getPConnect();
   const actionsApi = thePConn.getActionsApi();

--- a/src/components/forms/Dropdown/index.tsx
+++ b/src/components/forms/Dropdown/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import Utils from '../../../helpers/utils';
 import handleEvent from '../../../helpers/event-utils';
 import Select from '../../BaseComponents/Select/Select';
-import {useIsOnlyField, useStepName} from '../../../helpers/hooks/QuestionDisplayHooks';
+import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import useAddErrorToPageTitle from '../../../helpers/hooks/useAddErrorToPageTitle';
 
 interface IOption {
@@ -24,7 +24,6 @@ export default function Dropdown(props) {
 
   const [options, setOptions] = useState<Array<IOption>>([]);
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(isOnlyField, getPConnect);
 
   const thePConn = getPConnect();
   const actionsApi = thePConn.getActionsApi();
@@ -57,7 +56,7 @@ export default function Dropdown(props) {
 
   return (
     <>
-      <Select label={isOnlyField ? stepName: label}
+      <Select label={label}
        hintText={helperText}
        errorText={validatemessage}
        labelIsHeading={isOnlyField}

--- a/src/components/forms/RadioButtons/index.tsx
+++ b/src/components/forms/RadioButtons/index.tsx
@@ -20,7 +20,6 @@ export default function RadioButtons(props) {
   propName = propName.indexOf('.') === 0 ? propName.substring(1) : propName;
 
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(getPConnect);
 
   // TODO Investigate if this can be moved to 'higher' leven in component stack to avoid repititions
   useAddErrorToPageTitle(validatemessage);

--- a/src/components/forms/RadioButtons/index.tsx
+++ b/src/components/forms/RadioButtons/index.tsx
@@ -1,6 +1,6 @@
 import React  from 'react';
 import GDSRadioButtons from '../../BaseComponents/RadioButtons/RadioButtons';
-import {useIsOnlyField, useStepName} from '../../../helpers/hooks/QuestionDisplayHooks'
+import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks'
 import Utils from '../../../helpers/utils';
 
 export default function RadioButtons(props) {
@@ -17,7 +17,6 @@ export default function RadioButtons(props) {
   propName = propName.indexOf('.') === 0 ? propName.substring(1) : propName;
 
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(isOnlyField, getPConnect);
 
 
   // theOptions will be an array of JSON objects that are literally key/value pairs.
@@ -28,7 +27,7 @@ export default function RadioButtons(props) {
     <GDSRadioButtons
       {...props}
       name={propName}
-      label={isOnlyField?stepName:label}
+      label={label}
       legendIsHeading={isOnlyField}
       options={theOptions.map(option => {return {value:option.key, label:option.value}})}
       displayInline={theOptions.length === 2}

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import GDSTextInput from '../../BaseComponents/TextInput/TextInput';
 import useAddErrorToPageTitle from '../../../helpers/hooks/useAddErrorToPageTitle';
-import {useIsOnlyField, useStepName} from '../../../helpers/hooks/QuestionDisplayHooks';
+import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 
 export default function TextInput(props) {
   const {
@@ -39,7 +39,6 @@ export default function TextInput(props) {
   }
 
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(isOnlyField, getPConnect);
 
   return (
     <>
@@ -50,7 +49,7 @@ export default function TextInput(props) {
         }}
         hintText={helperText}
         errorText={validatemessage}
-        label={isOnlyField? stepName : label}
+        label={label}
         labelIsHeading={isOnlyField}
         name={propName}
       />

--- a/src/components/forms/TextInput/index.tsx
+++ b/src/components/forms/TextInput/index.tsx
@@ -39,7 +39,6 @@ export default function TextInput(props) {
   }
 
   const isOnlyField = useIsOnlyField();
-  const stepName = useStepName(getPConnect);
 
   return (
     <>

--- a/src/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/helpers/hooks/QuestionDisplayHooks.ts
@@ -8,12 +8,12 @@ declare const PCore;
 */
 
 
-function useIsOnlyField(){
+function useIsOnlyField(effectTrigger = null){
   const [isOnlyField, setisOnlyField] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
 
   useEffect ( () => {
     setisOnlyField(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
-  }, [])
+  }, [effectTrigger])
 
   return isOnlyField;
 }

--- a/src/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/helpers/hooks/QuestionDisplayHooks.ts
@@ -8,7 +8,7 @@ declare const PCore;
 */
 
 
-function useIsOnlyField(effectTrigger = null){
+export default function useIsOnlyField(effectTrigger = null){
   const [isOnlyField, setisOnlyField] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
 
   useEffect ( () => {
@@ -17,11 +17,3 @@ function useIsOnlyField(effectTrigger = null){
 
   return isOnlyField;
 }
-
-function useStepName(isOnlyField: boolean, getPConnect: Function){
-  const [stepName] = useState(getPConnect().getDataObject()?.caseInfo.assignments[0].name);
-  return stepName
-}
-
-
-export {useIsOnlyField, useStepName};


### PR DESCRIPTION
This change conditionally shows the step name as heading at assignment component if there is more than one field on the page. Otherwise it doesn't not display the heading, as this will be shown as part of the only field.

Functionality to set a field label to be the step name if it is the only field has been removed, as this will be handled pega side (Appropriate labels should be set in app)