### PR TITLE
Proposed fix for label heading bugs

### DIFF
--- a/src/components/templates/DefaultForm/index.tsx
+++ b/src/components/templates/DefaultForm/index.tsx
@@ -1,20 +1,27 @@
 import React, { createElement } from "react";
 
 import createPConnectComponent from '../../../bridge/react_pconnect';
+import isOnlyOneField from '../../../helpers/hooks/QuestionDisplayHooks';
 
 import './DefaultForm.css';
 
 export default function DefaultForm(props) {
   const { getPConnect } = props;
 
+  const onlyOneField = isOnlyOneField();
+
   // repoint the children because they are in a region and we need to not render the region
   // to take the children and create components for them, put in an array and pass as the
   // defaultForm kids
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
 
-  const dfChildren = arChildren.map((kid, idx) =>
-    createElement(createPConnectComponent(), { ...kid, key: idx }) // eslint-disable-line react/no-array-index-key
-  );
+  const dfChildren = arChildren.map((kid, idx) =>{
+    console.log(`${onlyOneField}`);
+    if(onlyOneField){
+      kid.getPConnect().setInheritedProp('label', getPConnect().getDataObject().caseInfo.assignments[0].name);
+    }
+    return createElement(createPConnectComponent(), { ...kid, key: idx }) // eslint-disable-line react/no-array-index-key
+  });
 
   return <>{dfChildren}</>;
 }

--- a/src/components/templates/DefaultForm/index.tsx
+++ b/src/components/templates/DefaultForm/index.tsx
@@ -16,8 +16,9 @@ export default function DefaultForm(props) {
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
 
   const dfChildren = arChildren.map((kid, idx) =>{
-    if(onlyOneField){
-      kid.getPConnect().setInheritedProp('label', getPConnect().getDataObject().caseInfo.assignments[0].name);
+    const childPConnect = kid.getPConnect();
+    if(onlyOneField && childPConnect.getConfigProps().readOnly !== true){
+      childPConnect.setInheritedProp('label', getPConnect().getDataObject().caseInfo.assignments[0].name);
     }
     return createElement(createPConnectComponent(), { ...kid, key: idx }) // eslint-disable-line react/no-array-index-key
   });

--- a/src/components/templates/DefaultForm/index.tsx
+++ b/src/components/templates/DefaultForm/index.tsx
@@ -16,7 +16,6 @@ export default function DefaultForm(props) {
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
 
   const dfChildren = arChildren.map((kid, idx) =>{
-    console.log(`${onlyOneField}`);
     if(onlyOneField){
       kid.getPConnect().setInheritedProp('label', getPConnect().getDataObject().caseInfo.assignments[0].name);
     }


### PR DESCRIPTION
To avoid adding the logic to each individual input component to replace it's label with the step name if it is the only question on the page, adding the logic to the DefaultForm component, which will check if there is only one editable field in the context, and pass the step name to the properties of that child.
