### PR TITLE
US-9361 - Further changes to Check answers screen for correct <dl> wrapping

### DIFF
--- a/src/components/Reference/index.tsx
+++ b/src/components/Reference/index.tsx
@@ -27,7 +27,8 @@ export default function Reference(props) {
   };
 
   const viewComponent = pConnect.createComponent(viewObject, null, null, {
-    pageReference: context
+    pageReference: context,
+    ...pConnect.getStateProps(),
   });
 
   viewComponent.props.getPConnect().setInheritedConfig({

--- a/src/components/View/index.tsx
+++ b/src/components/View/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getAllFields } from '../templates/utils';
-import ConditionalWrapper from '../../helpers/formatters/ConditionalWrapper';
 
 // Need to import any templates that we might render
 import CaseSummary from '../templates/CaseSummary';
@@ -39,7 +38,7 @@ import './View.css';
 //
 
 export default function View(props) {
-  const { children, template, getPConnect, mode, readOnly } = props;
+  const { children, template, getPConnect, mode } = props;
   let { label, showLabel = false } = props;
 
   // Get the inherited props from the parent to determine label settings. For 8.6, this is only for embedded data form views
@@ -183,15 +182,7 @@ export default function View(props) {
         {showLabel && template !== 'SubTabs' && template !== 'SimpleTable' && (
           <h2 className='govuk-heading-m'>{label}</h2>
         )}
-
-        {/* Conditional wrapping of a view in <dl> when read only. Currently expected only to be used in check answers screen */}
-        <ConditionalWrapper
-          condition={readOnly && mode === undefined && showLabel}
-          wrapper={child => <dl className="govuk-summary-list">
-            {child}
-          </dl>}
-          childrenToWrap={RenderedTemplate}
-        />
+        {RenderedTemplate}
       </>
     );
   }

--- a/src/components/templates/DefaultForm/index.tsx
+++ b/src/components/templates/DefaultForm/index.tsx
@@ -6,7 +6,7 @@ import isOnlyOneField from '../../../helpers/hooks/QuestionDisplayHooks';
 import './DefaultForm.css';
 
 export default function DefaultForm(props) {
-  const { getPConnect } = props;
+  const { getPConnect, readOnly, additionalProps } = props;
 
   const onlyOneField = isOnlyOneField();
 
@@ -14,14 +14,75 @@ export default function DefaultForm(props) {
   // to take the children and create components for them, put in an array and pass as the
   // defaultForm kids
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
+  let hasSingleChildWhichIsReference = false;
 
   const dfChildren = arChildren.map((kid, idx) =>{
+    let extraProps = {};
     const childPConnect = kid.getPConnect();
     if(onlyOneField && childPConnect.getConfigProps().readOnly !== true && idx === 0){
       childPConnect.setInheritedProp('label', getPConnect().getDataObject().caseInfo.assignments[0].name);
     }
-    return createElement(createPConnectComponent(), { ...kid, key: idx }) // eslint-disable-line react/no-array-index-key
+    if(readOnly) extraProps = {...extraProps, showLabel:false, labelHiddenForReadOnly:kid.showLabel};
+    return createElement(createPConnectComponent(), { ...kid, key: idx, ...extraProps }) // eslint-disable-line react/no-array-index-key
   });
+
+
+  // PM - This function batches the children of a DefaultForm, to group single in put fields togehter, or with preceeding sets of fields,
+  // creating a new 'batch' each time a child is a reference type, and will show label.
+  // Used when read only to avoid creating individual <dl> wrappers for individual fields, and to enable the correct wrapping of read only field
+  // in a <dl> when a label is being shown (as this needs to be displayed outside of the <dl> wrapper)
+  const batchChildren = (children) => {
+    let ind = 0;
+    const groupedChildren:any = [];
+
+    let group:any = [];
+
+    children.forEach( (child) => {
+
+      if(children.length > 1 && child.props.getPConnect().getMetadata().type === 'reference' && ind !== 0 && child.props.getPConnect().getInheritedProps().showLabel){
+        if(group.length > 0) {
+          groupedChildren.push(group)
+        }
+        groupedChildren.push([child]);
+        group = [];
+        ind+=1;
+        return;
+      }
+
+      group.push(child)
+      ind+=1;
+    })
+    if(group.length > 0){
+      groupedChildren.push(group);
+    }
+    return groupedChildren;
+  }
+
+  hasSingleChildWhichIsReference = (dfChildren?.length === 1 && dfChildren[0].props.getPConnect().getMetadata().type === "reference");
+
+  if(readOnly && !hasSingleChildWhichIsReference) {
+    return (batchChildren(dfChildren).map((childGroup, index) => {
+      if(childGroup.length < 1){
+        return;
+      }
+
+      const key = `${getPConnect().getMetadata().name}-${index}`
+
+      const allrefs = childGroup.every(child => child.props.getPConnect().getMetadata().type === 'reference');
+      if(additionalProps.hasBeenWrapped || allrefs){
+        return(
+          <React.Fragment key={key}>{childGroup}</React.Fragment>
+        )
+      }
+
+      childGroup.forEach( child => child.props.getPConnect().setStateProps({'hasBeenWrapped': true}));
+
+      return (<dl className="govuk-summary-list" key={key}>
+        {childGroup}
+      </dl>
+      )
+    }))
+  }
 
   return <>{dfChildren}</>;
 }


### PR DESCRIPTION
Adds logic to correctly wrap only the read only answers in <dl> Elements, with any headings and sub headings displayed outside of them.