### PR TITLE
BUG-5985 - Passes hasBeenWrapped prop properly to child components of Default Form

### DIFF
--- a/src/components/templates/DefaultForm/index.tsx
+++ b/src/components/templates/DefaultForm/index.tsx
@@ -36,6 +36,7 @@ export default function DefaultForm(props) {
     const formattedPropertyName = childPConnect.getStateProps().value && childPConnect.getStateProps().value.split('.').pop();
     const generatedName = props.context ? `${formattedContext}-${formattedPropertyName}`:`${formattedPropertyName}`;
     childPConnect.registerAdditionalProps({name: generatedName});
+    if(additionalProps.hasBeenWrapped) childPConnect.setStateProps({'hasBeenWrapped': true});
     return createElement(createPConnectComponent(), { ...kid, key: idx, extraProps }) // eslint-disable-line react/no-array-index-key
   });
 


### PR DESCRIPTION
Fixes check answers screen layout issue by passing 'hasBeenWrapped' prop, to stop nested <dl> components.