### PR TITLE
Bug 5925 - Fixes issue where in put on check answers screen takes the page title

### DIFF
--- a/src/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/helpers/hooks/QuestionDisplayHooks.ts
@@ -9,10 +9,13 @@ declare const PCore;
 
 
 export default function useIsOnlyField(effectTrigger = null){
-  const [isOnlyField, setisOnlyField] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
+  const [isOnlyField, setisOnlyField] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1
+  && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] != '0');
 
   useEffect ( () => {
     setisOnlyField(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
+    setisOnlyField(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1
+    && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] != '0');
   }, [effectTrigger])
 
   return isOnlyField;

--- a/src/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/helpers/hooks/QuestionDisplayHooks.ts
@@ -10,12 +10,11 @@ declare const PCore;
 
 export default function useIsOnlyField(effectTrigger = null){
   const [isOnlyField, setisOnlyField] = useState(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1
-  && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] != '0');
+  && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] !== '0');
 
   useEffect ( () => {
-    setisOnlyField(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1);
     setisOnlyField(PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1").length === 1
-    && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] != '0');
+    && PCore.getFormUtils().getEditableFields("root/primary_1/workarea_1")[0].fieldC11nEnv.getComponent().props.displayOrder.split('-')[0] === '0');
   }, [effectTrigger])
 
   return isOnlyField;


### PR DESCRIPTION
Updates the 'single editable input' hook logic to check that if there is only one editable field, it is the first thing on the page. Otherwise it should be considered to use it's own label and not the assignment title should not be hidden.