### PR TITLE
Manually reformats error messages for date component to be more GDS aligned

### DIFF
--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -6,6 +6,7 @@ import MultiStep from '../MultiStep';
 import useIsOnlyField from '../../helpers/hooks/QuestionDisplayHooks';
 import useAddErrorToPageTitle from '../../helpers/hooks/useAddErrorToPageTitle';
 import ErrorSummary from '../BaseComponents/ErrorSummary/ErrorSummary';
+import { DateErrorFormatter } from '../../helpers/formatters/DateErrorFormatter';
 
 export interface ErrorMessageDetails{
   message:string,
@@ -128,8 +129,8 @@ export default function Assignment(props) {
       const fieldComponent = fieldC11nEnv.getComponent();
       if(fieldStateprops && fieldStateprops.validatemessage && fieldStateprops.validatemessage !== ''){
         const fieldId = fieldC11nEnv.getStateProps().fieldId || fieldComponent.props.name;
-
-        acc.push({message:{message:fieldStateprops.validatemessage, fieldId}, displayOrder:fieldComponent.props.displayOrder});
+        let validatemessage = fieldC11nEnv.getMetadata().type === 'Date' ? DateErrorFormatter(fieldStateprops.validatemessage, fieldC11nEnv.resolveConfigProps(fieldC11nEnv.getMetadata().config).label) : fieldStateprops.validatemessage
+        acc.push({message:{message:validatemessage, fieldId}, displayOrder:fieldComponent.props.displayOrder});
       }
         return acc;
       }, [] );

--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -129,7 +129,7 @@ export default function Assignment(props) {
       const fieldComponent = fieldC11nEnv.getComponent();
       if(fieldStateprops && fieldStateprops.validatemessage && fieldStateprops.validatemessage !== ''){
         const fieldId = fieldC11nEnv.getStateProps().fieldId || fieldComponent.props.name;
-        let validatemessage = fieldC11nEnv.getMetadata().type === 'Date' ? DateErrorFormatter(fieldStateprops.validatemessage, fieldC11nEnv.resolveConfigProps(fieldC11nEnv.getMetadata().config).label) : fieldStateprops.validatemessage
+        const validatemessage = fieldC11nEnv.getMetadata().type === 'Date' ? DateErrorFormatter(fieldStateprops.validatemessage, fieldC11nEnv.resolveConfigProps(fieldC11nEnv.getMetadata().config).label) : fieldStateprops.validatemessage
         acc.push({message:{message:validatemessage, fieldId}, displayOrder:fieldComponent.props.displayOrder});
       }
         return acc;

--- a/src/components/BaseComponents/DateInput/DateInput.tsx
+++ b/src/components/BaseComponents/DateInput/DateInput.tsx
@@ -5,11 +5,15 @@ import FieldSet from '../FormGroup/FieldSet'
 
 export default function DateInput(props){
 
-  const {name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, inputProps={}} = props;
+  const {name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, inputProps={}, errorProps={specificError:{day:true, month:true, year:true}}} = props;
 
-  const inputClasses = `govuk-input ${errorText?'govuk-input--error':""} ${inputProps.className}`.trim();
-  const dateInputClassesWithWidth = (width: number) => {
-    return `${inputClasses} govuk-input--width-${width}`.trim();
+  const inputClasses = `govuk-input ${inputProps.className}`.trim();
+  const widthClass= (width: number) => {
+    return `govuk-input--width-${width}`;
+  }
+
+  const errorClass= (targetOfError: boolean) => {
+    return `${targetOfError?'govuk-input--error':null}`;
   }
 
   // NOTE - Calculating outside of JSX incase of future translation requirements
@@ -27,7 +31,7 @@ export default function DateInput(props){
       <div className="govuk-date-input" id={name}>
         <div className="govuk-date-input__item">
           <FormGroup name={`${name}-day`} label={dayLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label">
-            <input className={dateInputClassesWithWidth(2)}
+            <input className={[inputClasses, widthClass(2), errorClass(errorProps?.specificError?.day)].join(' ')}
               id={`${name}-day`} name={`${name}-day`} type="text"
               inputMode="numeric" value={value?.day}
               onChange={onChangeDay} />
@@ -35,7 +39,7 @@ export default function DateInput(props){
         </div>
         <div className="govuk-date-input__item">
           <FormGroup name={`${name}-month`} label={monthLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label">
-            <input className={dateInputClassesWithWidth(2)}
+            <input className={[inputClasses, widthClass(2), errorClass(errorProps?.specificError?.month)].join(' ')}
               id={`${name}-month`} name={`${name}-month`} type="text"
               inputMode="numeric" value={value?.month}
               onChange={onChangeMonth}
@@ -44,7 +48,7 @@ export default function DateInput(props){
         </div>
         <div className="govuk-date-input__item">
           <FormGroup name={`${name}-year`} label={yearLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label"></FormGroup>
-          <input className={dateInputClassesWithWidth(4)}
+          <input className={[inputClasses, widthClass(4), errorClass(errorProps?.specificError?.year)].join(' ')}
             id={`${name}-year`} name={`${name}-year`} type="text"
             inputMode="numeric" value={value?.year}
             onChange={onChangeYear}
@@ -62,5 +66,6 @@ DateInput.propTypes = {
   onChangeDay: PropTypes.func,
   onChangeMonth: PropTypes.func,
   onChangeYear: PropTypes.func,
-  value: PropTypes.shape({day:PropTypes.string, month:PropTypes.string, year:PropTypes.string})
+  value: PropTypes.shape({day:PropTypes.string, month:PropTypes.string, year:PropTypes.string}),
+  errorProps: PropTypes.shape({specificError:PropTypes.shape({day:PropTypes.bool, month:PropTypes.bool, year:PropTypes.bool})}),
 }

--- a/src/components/BaseComponents/DateInput/DateInput.tsx
+++ b/src/components/BaseComponents/DateInput/DateInput.tsx
@@ -15,7 +15,8 @@ export default function DateInput(props){
     }
   }
 
-  const inputClasses = `govuk-input ${inputProps.className?inputProps.className:''}`.trim();
+  const inputClasses = `govuk-input ${inputProps.className?inputProps.className:''
+}`.trim();
   const widthClass= (width: number) => {
     return `govuk-input--width-${width}`;
   }

--- a/src/components/BaseComponents/DateInput/DateInput.tsx
+++ b/src/components/BaseComponents/DateInput/DateInput.tsx
@@ -5,15 +5,25 @@ import FieldSet from '../FormGroup/FieldSet'
 
 export default function DateInput(props){
 
-  const {name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, inputProps={}, errorProps={specificError:{day:true, month:true, year:true}}} = props;
+  const {name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, inputProps={}} = props;
+  let {errorProps} = props;
 
-  const inputClasses = `govuk-input ${inputProps.className}`.trim();
+  if(!errorProps){
+    errorProps = {};
+    if(!errorProps.specificError){
+      errorProps.specificError={day:true, month:true, year:true};
+    }
+  }
+
+  const inputClasses = `govuk-input ${inputProps.className?inputProps.className:''}`.trim();
   const widthClass= (width: number) => {
     return `govuk-input--width-${width}`;
   }
 
   const errorClass= (targetOfError: boolean) => {
-    return `${targetOfError?'govuk-input--error':null}`;
+    if(errorText){
+      return `${targetOfError?'govuk-input--error':null}`;
+    }
   }
 
   // NOTE - Calculating outside of JSX incase of future translation requirements

--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -39,10 +39,6 @@ export default function Date(props) {
     handleDateChange();
   }, [day, month, year]);
 
-  if (readOnly) {
-    return <ReadOnlyDisplay label={label} value={new global.Date(value).toLocaleDateString()} />;
-  }
-
   useEffect(()=>{
     if(validatemessage){
       setEditedValidateMessage(DateErrorFormatter(validatemessage, getPConnect().resolveConfigProps(getPConnect().getMetadata().config).label));

--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useLayoutEffect } from 'react';
+import React, { useState, useLayoutEffect, useEffect } from 'react';
 import DateInput from '../../BaseComponents/DateInput/DateInput';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+import {DateErrorFormatter, DateErrorTargetFields} from '../../../helpers/formatters/DateErrorFormatter';
 
 declare const global;
 
@@ -15,6 +16,8 @@ export default function Date(props) {
   const [day, setDay] = useState(value ? value.split('-')[2] : '');
   const [month, setMonth] = useState(value ? value.split('-')[1] : '');
   const [year, setYear] = useState(value ? value.split('-')[0] : '');
+  const [editedValidateMessage, setEditedValidateMessage] = useState(validatemessage);
+  const [specificErrors, setSpecificErrors] = useState<any>(null)
 
   // PM - Create ISODate string (as expected by onChange) and pass to onchange value, adding 0 padding here for day and month to comply with isostring format.
   const handleDateChange = () => {
@@ -39,6 +42,18 @@ export default function Date(props) {
   if (readOnly) {
     return <ReadOnlyDisplay label={label} value={new global.Date(value).toLocaleDateString()} />;
   }
+
+  useEffect(()=>{
+    if(validatemessage){
+      setEditedValidateMessage(DateErrorFormatter(validatemessage, getPConnect().resolveConfigProps(getPConnect().getMetadata().config).label));
+
+      const errorTargets = DateErrorTargetFields(validatemessage);
+      let specificError:any = null;
+      if(errorTargets.length > 0) specificError = {day: errorTargets.includes('day'), month: errorTargets.includes('month'), year: errorTargets.includes('year')};
+
+      setSpecificErrors(specificError);
+    }
+  }, [validatemessage]);
 
   // This sets a state prop to be exposed to the error summary set up in Assisgnment component - and should match the id of the first field of
   // the date component. Will investigate better way to do this, to avoid mismatches if the Date BaseComponent changes.
@@ -69,8 +84,9 @@ export default function Date(props) {
       onChangeYear={handleChangeYear}
       value={{ day, month, year }}
       name={name}
-      errorText={validatemessage}
+      errorText={editedValidateMessage}
       hintText={helperText}
+      errorProps={specificErrors?{specificError:specificErrors}:null}
     />
   );
 }

--- a/src/components/forms/Date/index.tsx
+++ b/src/components/forms/Date/index.tsx
@@ -18,6 +18,7 @@ export default function Date(props) {
   const [year, setYear] = useState(value ? value.split('-')[0] : '');
   const [editedValidateMessage, setEditedValidateMessage] = useState(validatemessage);
   const [specificErrors, setSpecificErrors] = useState<any>(null)
+  pConn.setStateProps({fieldId: `${name}-day`});
 
   // PM - Create ISODate string (as expected by onChange) and pass to onchange value, adding 0 padding here for day and month to comply with isostring format.
   const handleDateChange = () => {
@@ -47,13 +48,21 @@ export default function Date(props) {
       let specificError:any = null;
       if(errorTargets.length > 0) specificError = {day: errorTargets.includes('day'), month: errorTargets.includes('month'), year: errorTargets.includes('year')};
 
+      // This sets a state prop to be exposed to the error summary set up in Assisgnment component - and should match the id of the first field of
+      // the date component. Will investigate better way to do this, to avoid mismatches if the Date BaseComponent changes.
+
+      if(!specificError?.day){
+        if(specificError?.month){
+          pConn.setStateProps({fieldId: `${name}-month`});
+        } else if (specificError?.year){
+          pConn.setStateProps({fieldId: `${name}-year`});
+        }
+      }
       setSpecificErrors(specificError);
     }
   }, [validatemessage]);
 
-  // This sets a state prop to be exposed to the error summary set up in Assisgnment component - and should match the id of the first field of
-  // the date component. Will investigate better way to do this, to avoid mismatches if the Date BaseComponent changes.
-  pConn.setStateProps({fieldId: `${name}-day`});
+
 
   // PM - Handlers for each part of date inputs, update state for each respectively
   //      0 pad for ISOString compatibilitiy, with conditions to allow us to clear the fields

--- a/src/helpers/formatters/DateErrorFormatter.js
+++ b/src/helpers/formatters/DateErrorFormatter.js
@@ -2,15 +2,12 @@
 const _DateErrorFormatter = (message, propertyName) => {
 
   const dateRegExp = /(\d*-\d*-\d*)/;
-  const originalDate = message.match(dateRegExp)[0];
-  let correctedDate;
-  let targets = []
-
-  let newMessage = message;
+  const matchedDates = message.match(dateRegExp);
+  const originalDate = (matchedDates?.length > 0) ? matchedDates[0] : null;
+  const targets = []
 
   if(originalDate){
      const [year, month, day] = originalDate.split('-');
-     correctedDate = `${day}/${month}/${year}`;
 
     // When some 'parts' are missing
     let missingPartMessage = ''
@@ -19,23 +16,25 @@ const _DateErrorFormatter = (message, propertyName) => {
       targets.push('day');
     }
     if(month === ''){
-      missingPartMessage.length > 0 ? missingPartMessage+=' and a month' : missingPartMessage+='a month';
+      if(missingPartMessage.length > 0)  missingPartMessage+=' and a month';
+      else missingPartMessage+='a month';
       targets.push('month');
     }
     if(year === ''){
-      missingPartMessage.length > 0 ? missingPartMessage+=' and a year' : missingPartMessage+='a year';
+      if(missingPartMessage.length > 0) missingPartMessage+=' and a year'
+      else missingPartMessage+='a year';
       targets.push('year');
     }
     if(missingPartMessage.length > 0){
-      return {message: `${propertyName} must include ${missingPartMessage}`, targets:targets};
+      return {message: `${propertyName} must include ${missingPartMessage}`, targets};
     }
 
-    if(message.find('is not a valid date')){
-      return {message: `${propertyName} must include ${missingPartMessage}` `${propertyName} must be a real date`, targets};
+    if(message.search('is not a valid date')){
+      return {message: `${propertyName} must be a real date`, targets};
     }
 
   }
-  return {message:message, targets:targets};
+  return {message, targets};
 }
 
 export const DateErrorFormatter = (message, propertyName) => {

--- a/src/helpers/formatters/DateErrorFormatter.js
+++ b/src/helpers/formatters/DateErrorFormatter.js
@@ -1,0 +1,47 @@
+
+const _DateErrorFormatter = (message, propertyName) => {
+
+  const dateRegExp = /(\d*-\d*-\d*)/;
+  const originalDate = message.match(dateRegExp)[0];
+  let correctedDate;
+  let targets = []
+
+  let newMessage = message;
+
+  if(originalDate){
+     const [year, month, day] = originalDate.split('-');
+     correctedDate = `${day}/${month}/${year}`;
+
+    // When some 'parts' are missing
+    let missingPartMessage = ''
+    if(day === ''){
+      missingPartMessage += 'a day';
+      targets.push('day');
+    }
+    if(month === ''){
+      missingPartMessage.length > 0 ? missingPartMessage+=' and a month' : missingPartMessage+='a month';
+      targets.push('month');
+    }
+    if(year === ''){
+      missingPartMessage.length > 0 ? missingPartMessage+=' and a year' : missingPartMessage+='a year';
+      targets.push('year');
+    }
+    if(missingPartMessage.length > 0){
+      return {message: `${propertyName} must include ${missingPartMessage}`, targets:targets};
+    }
+
+    if(message.find('is not a valid date')){
+      return {message: `${propertyName} must include ${missingPartMessage}` `${propertyName} must be a real date`, targets};
+    }
+
+  }
+  return {message:message, targets:targets};
+}
+
+export const DateErrorFormatter = (message, propertyName) => {
+  return _DateErrorFormatter(message, propertyName).message;
+}
+
+export const DateErrorTargetFields = (message) => {
+  return _DateErrorFormatter(message, null).targets;
+}

--- a/tests/unit/components/BaseComponents/__snapshots__/DateInput.test.tsx.snap
+++ b/tests/unit/components/BaseComponents/__snapshots__/DateInput.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Basic date input component hint and error 1`] = `
             Day
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-day"
             inputMode="numeric"
             name="name-day"
@@ -69,7 +69,7 @@ exports[`Basic date input component hint and error 1`] = `
             Month
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-month"
             inputMode="numeric"
             name="name-month"
@@ -91,7 +91,7 @@ exports[`Basic date input component hint and error 1`] = `
           </label>
         </div>
         <input
-          className="govuk-input govuk-input--error undefined govuk-input--width-4"
+          className="govuk-input govuk-input--width-4 govuk-input--error"
           id="name-year"
           inputMode="numeric"
           name="name-year"
@@ -149,7 +149,7 @@ exports[`Basic date input component prepoulated with a date 1`] = `
             Day
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-day"
             inputMode="numeric"
             name="name-day"
@@ -171,7 +171,7 @@ exports[`Basic date input component prepoulated with a date 1`] = `
             Month
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-month"
             inputMode="numeric"
             name="name-month"
@@ -194,7 +194,7 @@ exports[`Basic date input component prepoulated with a date 1`] = `
           </label>
         </div>
         <input
-          className="govuk-input govuk-input--error undefined govuk-input--width-4"
+          className="govuk-input govuk-input--width-4 govuk-input--error"
           id="name-year"
           inputMode="numeric"
           name="name-year"
@@ -259,7 +259,7 @@ exports[`Basic date input component with legend as h1 1`] = `
             Day
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-day"
             inputMode="numeric"
             name="name-day"
@@ -281,7 +281,7 @@ exports[`Basic date input component with legend as h1 1`] = `
             Month
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-month"
             inputMode="numeric"
             name="name-month"
@@ -304,7 +304,7 @@ exports[`Basic date input component with legend as h1 1`] = `
           </label>
         </div>
         <input
-          className="govuk-input govuk-input--error undefined govuk-input--width-4"
+          className="govuk-input govuk-input--width-4 govuk-input--error"
           id="name-year"
           inputMode="numeric"
           name="name-year"
@@ -363,7 +363,7 @@ exports[`Basic date input componentwith error applying to whole input 1`] = `
             Day
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-day"
             inputMode="numeric"
             name="name-day"
@@ -384,7 +384,7 @@ exports[`Basic date input componentwith error applying to whole input 1`] = `
             Month
           </label>
           <input
-            className="govuk-input govuk-input--error undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 govuk-input--error"
             id="name-month"
             inputMode="numeric"
             name="name-month"
@@ -406,7 +406,7 @@ exports[`Basic date input componentwith error applying to whole input 1`] = `
           </label>
         </div>
         <input
-          className="govuk-input govuk-input--error undefined govuk-input--width-4"
+          className="govuk-input govuk-input--width-4 govuk-input--error"
           id="name-year"
           inputMode="numeric"
           name="name-year"
@@ -450,7 +450,7 @@ exports[`renders correctly 1`] = `
             Day
           </label>
           <input
-            className="govuk-input  undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 "
             id="undefined-day"
             inputMode="numeric"
             name="undefined-day"
@@ -471,7 +471,7 @@ exports[`renders correctly 1`] = `
             Month
           </label>
           <input
-            className="govuk-input  undefined govuk-input--width-2"
+            className="govuk-input govuk-input--width-2 "
             id="undefined-month"
             inputMode="numeric"
             name="undefined-month"
@@ -493,7 +493,7 @@ exports[`renders correctly 1`] = `
           </label>
         </div>
         <input
-          className="govuk-input  undefined govuk-input--width-4"
+          className="govuk-input govuk-input--width-4 "
           id="undefined-year"
           inputMode="numeric"
           name="undefined-year"


### PR DESCRIPTION
In the case of missing day, month and/or year - displays a message pointing out what is missing. Error highlights the fields that are missing, and sets the summary link to point to the first missing element. 

In case of invalid date, - updates the message to follow format '[property name] must be a real date'
