### PR TITLE
US-9821 

### DIFF
--- a/src/bridge/react_pconnect.jsx
+++ b/src/bridge/react_pconnect.jsx
@@ -53,6 +53,7 @@ import DataReference from '../components/templates/DataReference';
 import SemanticLink from '../components/forms/SemanticLink';
 import UserReference from '../components/forms/UserReference';
 import ChangeLink from '../components/forms/ChangeLink';
+import Group from '../components/forms/Group'
 
 const connectRedux = (component, c11nEnv) => {
 
@@ -337,6 +338,10 @@ const getComponent = (c11nEnv, declarative) => {
 
       case 'HMRC_ODX_PhoneNumber':
         component = Phone;
+        break;
+
+      case 'Group':
+        component = Group;
         break;
 
       default:

--- a/src/components/BaseComponents/Checkboxes/Checkboxes.tsx
+++ b/src/components/BaseComponents/Checkboxes/Checkboxes.tsx
@@ -5,7 +5,6 @@ import GDSCheckbox from './Checkbox'
 
 export default function Checkboxes(props) {
   const {
-    name,
     optionsList,
     onBlur,
     inputProps,
@@ -21,10 +20,11 @@ export default function Checkboxes(props) {
           <GDSCheckbox
             item={item}
             index={index}
-            name={name}
+            name={item.name}
             inputProps={...inputProps}
             onChange={item.onChange}
             onBlur={onBlur}
+            key={item.name}
           />
         ))}
       </div>

--- a/src/components/BaseComponents/Checkboxes/Checkboxes.tsx
+++ b/src/components/BaseComponents/Checkboxes/Checkboxes.tsx
@@ -7,7 +7,6 @@ export default function Checkboxes(props) {
   const {
     name,
     optionsList,
-    onChange,
     onBlur,
     inputProps,
   } = props;
@@ -24,7 +23,7 @@ export default function Checkboxes(props) {
             index={index}
             name={name}
             inputProps={...inputProps}
-            onChange={onChange}
+            onChange={item.onChange}
             onBlur={onBlur}
           />
         ))}
@@ -35,12 +34,15 @@ export default function Checkboxes(props) {
 
 Checkboxes.propTypes = {
   name: PropTypes.string,
-  label: PropTypes.string,
-  legendIsHeading: PropTypes.bool,
-  optionsList: PropTypes.array,
-  errorText: PropTypes.string,
-  hintText: PropTypes.string,
+  optionsList: PropTypes.arrayOf(PropTypes.shape({
+    checked: PropTypes.bool,
+    label: PropTypes.string,
+    hintText: PropTypes.string,
+    readOnly:PropTypes.bool,
+    onChange:PropTypes.func})
+  ),
   inputProps: PropTypes.object,
   onChange: PropTypes.func,
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  ...FieldSet.propTypes ,
 };

--- a/src/components/BaseComponents/FormGroup/FieldSet.tsx
+++ b/src/components/BaseComponents/FormGroup/FieldSet.tsx
@@ -54,4 +54,5 @@ FieldSet.propTypes = {
   errorText: PropTypes.string,
   children: PropTypes.node,
   fieldsetElementProps: PropTypes.object,
+  instructionText: PropTypes.string
 }

--- a/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
+++ b/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
@@ -12,7 +12,7 @@ export default function ReadOnlyDisplay(props){
       <dd className="govuk-summary-list__value">
       { Array.isArray(value) ?
         <ul className="govuk-list">
-          {value.map( valueItem => <li>{valueItem}</li>)}
+          {value.map( valueItem => <li key={valueItem}>{valueItem}</li>)}
         </ul>
         :
         value
@@ -24,5 +24,5 @@ export default function ReadOnlyDisplay(props){
 
 ReadOnlyDisplay.propTypes = {
   label: PropTypes.string,
-  value: PropTypes.string || PropTypes.arrayOf(PropTypes.string),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
 }

--- a/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
+++ b/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function ReadOnlyDisplay(props){
 
@@ -7,7 +8,21 @@ export default function ReadOnlyDisplay(props){
   return (
     <div className="govuk-summary-list__row">
       <dt className="govuk-summary-list__key">{label}</dt>
-      <dd className="govuk-summary-list__value">{value}</dd>
+
+      <dd className="govuk-summary-list__value">
+      { Array.isArray(value) ?
+        <ul className="govuk-list">
+          {value.map( value => <li>{value}</li>)}
+        </ul>
+        :
+        value
+      } </dd>
     </div>
   )
+}
+
+
+ReadOnlyDisplay.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.string || PropTypes.arrayOf(PropTypes.string),
 }

--- a/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
+++ b/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
@@ -12,7 +12,7 @@ export default function ReadOnlyDisplay(props){
       <dd className="govuk-summary-list__value">
       { Array.isArray(value) ?
         <ul className="govuk-list">
-          {value.map( value => <li>{value}</li>)}
+          {value.map( valueItem => <li>{valueItem}</li>)}
         </ul>
         :
         value

--- a/src/components/forms/Checkbox/index.tsx
+++ b/src/components/forms/Checkbox/index.tsx
@@ -29,12 +29,11 @@ export default function CheckboxComponent(props) {
       return (<ReadOnlyDisplay value={value?props.trueLabel:props.falseLabel} label={caption}/>)
   }
 
-  const optionsList = [{checked: value, label: caption, hintText: " ", readOnly:false}]
-
   const handleChange = event => {
     handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
   };
 
+  const optionsList = [{checked: value, label: caption, hintText: " ", readOnly:false, onChange:handleChange}]
 
   const extraProps= {testProps:{'data-test-id':testId}};
 
@@ -48,7 +47,7 @@ export default function CheckboxComponent(props) {
         legendIsHeading={isOnlyField}
         errorText={validatemessage}
         hintText={hintText}
-        onChange={ handleChange}
+        onChange={handleChange}
         {...extraProps}
       />
     </>

--- a/src/components/forms/Checkbox/index.tsx
+++ b/src/components/forms/Checkbox/index.tsx
@@ -33,7 +33,7 @@ export default function CheckboxComponent(props) {
     handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
   };
 
-  const optionsList = [{checked: value, label: caption, hintText: " ", readOnly:false, onChange:handleChange}]
+  const optionsList = [{checked: value, label: caption, hintText: " ", readOnly:false, name, onChange:handleChange}]
 
   const extraProps= {testProps:{'data-test-id':testId}};
 

--- a/src/components/forms/Group/index.tsx
+++ b/src/components/forms/Group/index.tsx
@@ -1,0 +1,87 @@
+import React, {useState, useEffect} from 'react'
+import CheckBoxes from '../../BaseComponents/Checkboxes/Checkboxes';
+import handleEvent from '../../../helpers/event-utils';
+import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
+import ReadOnlyDisplay from '../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+
+export default function Group(props){
+  const { children, name, heading, instructions, readOnly, getPConnect } = props;
+
+  const thePConn = getPConnect();
+  const actionsApi = thePConn.getActionsApi();
+  const [stateChanged, setStateChanged] = useState(false);
+
+  const isOnlyField = useIsOnlyField();
+
+  // Doesn't seem that state change on children (checkboxes) causes refresh on the containing group,
+  // working around with this for now
+  useEffect(()=>{
+    if (stateChanged) {
+      setStateChanged(false);
+    }
+  }, [stateChanged]);
+
+  if(children.length > 0){
+    const handleChange = (event, propName) => {
+      console.log('cally wally group');
+      handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
+      setStateChanged(true);
+    };
+
+    const errors = [""];
+    if(children[0].props?.getPConnect().getMetadata().type === 'Checkbox'){
+
+      if(readOnly){
+        const valuesList = children.filter( (child) => {
+          const childPConnect = child.props.getPConnect();
+          const resolvedProps = childPConnect.resolveConfigProps(childPConnect.getConfigProps())
+          return (resolvedProps.value);
+        }).map((child) => {
+            const childPConnect = child.props.getPConnect();
+            const resolvedProps = childPConnect.resolveConfigProps(childPConnect.getConfigProps())
+            return (resolvedProps.caption);
+          }
+        )
+        return (<ReadOnlyDisplay value={valuesList} label={heading}/>)
+      }
+
+
+      const optionsList = children.map( child => {
+        const childPConnect = child.props.getPConnect();
+        const resolvedProps = childPConnect.resolveConfigProps(childPConnect.getConfigProps())
+        childPConnect.populateAdditionalProps(childPConnect.getConfigProps());
+        errors.push(childPConnect.getStateProps().validatemessage)
+
+        // Points error summary link to first checkbox in group
+        childPConnect.setStateProps({fieldId: `${name}`});
+
+        return {
+            checked: resolvedProps.value,
+            label: resolvedProps.caption,
+            hintText: " ",
+            readOnly: resolvedProps.readOnly,
+            onChange: event => handleChange(event, childPConnect.getStateProps().value),
+        }
+      })
+      return (<>
+        <CheckBoxes
+        optionsList={optionsList}
+        name={name}
+        onChange={handleChange}
+        label={heading}
+        instructionText={instructions}
+        legendIsHeading={isOnlyField}
+        errorText={errors.join(' ').trim() !== '' ? errors.join(' ').trim() : null}
+        />
+      </>);
+    }
+  }
+
+  return (<>
+  {...children}
+  </>);
+}
+
+
+Group.propTypes = {
+}

--- a/src/components/forms/Group/index.tsx
+++ b/src/components/forms/Group/index.tsx
@@ -23,7 +23,6 @@ export default function Group(props){
 
   if(children.length > 0){
     const handleChange = (event, propName) => {
-      console.log('cally wally group');
       handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
       setStateChanged(true);
     };
@@ -63,6 +62,7 @@ export default function Group(props){
             onChange: event => handleChange(event, childPConnect.getStateProps().value),
         }
       })
+
       return (<>
         <CheckBoxes
         optionsList={optionsList}


### PR DESCRIPTION
Adds new group component, with special handling for groups of check boxes.
This handling extracts individual error messages and displays them at top of group, and handles rendering of each checkbox.
Also adds handling for read only checkbox display, showing a list of selected values in the right column of check your answers.


Also tweaks the checkboxes base component to handle sets of checkboxes. retrofits the SDK checkbox to comply with these changes.

