### PR TITLE
Fast hosts ref changes (US-10173)

### DIFF
--- a/src/applications/AppSelector/index.tsx
+++ b/src/applications/AppSelector/index.tsx
@@ -5,7 +5,6 @@ import ChildBenefitsClaim from '../ChildBenefitsClaim'
 // NOTE: You should update this to be the same value that's in
 //  the src/index.html <base href="value"> to allow the React Router
 //  to identify the paths correctly.
-const baseURL = "/";
 
 // The Main component renders one of the three provided
 // Routes (provided that one matches). Both the /roster
@@ -16,8 +15,7 @@ const AppSelector = () => {
 
   return (
     <Routes>
-      <Route path={`${baseURL}`} element={<ChildBenefitsClaim />} />
-      <Route path={`${baseURL}claim-child-benefit`} element={<ChildBenefitsClaim/>} />
+      <Route path="*" element={<ChildBenefitsClaim />} />
     </Routes>
   )
 

--- a/src/helpers/config_access.js
+++ b/src/helpers/config_access.js
@@ -54,7 +54,7 @@ class ConfigAccess {
   fixupConfigSettings() {
     const oServerConfig = this.sdkConfig["serverConfig"];
     // If not present, then use current root path
-    oServerConfig.sdkContentServerUrl = oServerConfig.sdkContentServerUrl || window.location.origin;
+    oServerConfig.sdkContentServerUrl = oServerConfig.sdkContentServerUrl || window.location.origin + window.location.pathname;
     // Needs a trailing slash so add one if not there
     if( !oServerConfig.sdkContentServerUrl.endsWith('/') ) {
       oServerConfig.sdkContentServerUrl = `${oServerConfig.sdkContentServerUrl}/`;


### PR DESCRIPTION
This change allows for various paths such as /dt1/ and /stg1/ for the website hosted on fastshosts to now correctly route to the child benefit application

Due to there being paths in fasthosts, a further change is required to ensure that constellation is using files from the subfolder as opposed to the root folder (in case we need to version constellation between environments)