### PR TITLE
Link button classes now correctly handled

### DIFF
--- a/src/components/BaseComponents/Button/Button.tsx
+++ b/src/components/BaseComponents/Button/Button.tsx
@@ -39,7 +39,7 @@ export default function Button(props) {
   } else if (variant === 'link') {
     return (
       <div className='govuk-button-group'>
-        <a className='govuk-link' href='#' onClick={onClick} {...attributes}>
+        <a {...attributes} className={'govuk-link'.concat(' ', attributes.className)} href='#' onClick={onClick} >
           {children}
         </a>
       </div>


### PR DESCRIPTION
Small fix to the styling of 'link' buttons.

Classes were being overwritten by extra attributes. Now any classNames passed via attributes are appended to the default link style class.