### PR TITLE
BUG-6389 - Update page title when progressing through the application

### DIFF
--- a/src/applications/ChildBenefitsClaim/index.tsx
+++ b/src/applications/ChildBenefitsClaim/index.tsx
@@ -12,6 +12,7 @@ import StartPage from './StartPage';
 import ConfirmationPage from './ConfirmationPage';
 import UserPortal from './UserPortal';
 import ClaimsList from '../../components/templates/ClaimsList';
+import setPageTitle from '../../helpers/setPageTitleHelpers';
 
 // declare var gbLoggedIn: boolean;
 // declare var login: Function;
@@ -31,6 +32,10 @@ export default function ChildBenefitsClaim() {
   const [loadingsubmittedClaims, setLoadingSubmittedClaims] = useState(true);
   const [loadinginProgressClaims, setLoadingInProgressClaims] = useState(true);
   let operatorId = '';
+
+  useEffect(()=> {
+    setPageTitle();
+  }, [showStartPage, showUserPortal, bShowPega, bShowResolutionScreen]);
 
   const [inprogressClaims, setInprogressClaims] = useState([]);
   const [submittedClaims, setSubmittedClaims] = useState([]);

--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -8,7 +8,7 @@ import useAddErrorToPageTitle from '../../helpers/hooks/useAddErrorToPageTitle';
 import ErrorSummary from '../BaseComponents/ErrorSummary/ErrorSummary';
 import { DateErrorFormatter } from '../../helpers/formatters/DateErrorFormatter';
 import Button from '../BaseComponents/Button/Button';
-
+import setPageTitle from '../../helpers/setPageTitleHelpers';
 export interface ErrorMessageDetails {
   message: string;
   fieldId: string;
@@ -46,6 +46,10 @@ export default function Assignment(props) {
 
   const isOnlyOneField = useIsOnlyField();
   const containerName = thePConn.getDataObject().caseInfo.assignments[0].name;
+
+  useEffect(() => {
+    setPageTitle();
+  },[children])
 
   function findCurrentIndicies(
     arStepperSteps: Array<any>,

--- a/src/components/Assignment/index.tsx
+++ b/src/components/Assignment/index.tsx
@@ -9,6 +9,7 @@ import ErrorSummary from '../BaseComponents/ErrorSummary/ErrorSummary';
 import { DateErrorFormatter } from '../../helpers/formatters/DateErrorFormatter';
 import Button from '../BaseComponents/Button/Button';
 import setPageTitle from '../../helpers/setPageTitleHelpers';
+
 export interface ErrorMessageDetails {
   message: string;
   fieldId: string;

--- a/src/components/ViewContainer/index.tsx
+++ b/src/components/ViewContainer/index.tsx
@@ -5,6 +5,7 @@ import createPConnectComponent from "../../bridge/react_pconnect";
 import StoreContext from "../../bridge/Context/StoreContext";
 import Utils from '../../helpers/utils';
 import Button from '../../components/BaseComponents/Button/Button';
+import setPageTitle from '../../helpers/setPageTitleHelpers';
 // ViewContainer can emit View
 // import View from '../View';
 
@@ -22,6 +23,10 @@ export default function ViewContainer(props) {
   const { getPConnect, name, mode, limit, loadingInfo, routingInfo } = props;
 
   const { displayOnlyFA } = useContext(StoreContext);
+
+  useEffect(()=>{
+    setPageTitle();
+  }, [])
 
 
   const { CONTAINER_TYPE, APP } = PCore.getConstants();

--- a/src/helpers/setPageTitleHelpers.ts
+++ b/src/helpers/setPageTitleHelpers.ts
@@ -1,0 +1,19 @@
+
+/*
+  setPageTile(pageHeading:string, serviceName:string)
+  Sets page title to in following pattern
+  <<pageHeading>> - <<serviceName>> - GOV.UK`
+*/
+export default function setPageTitle(){
+
+  const pageHeading = document.getElementsByTagName('h1')[0]?.innerText
+
+  // Scope to fetch serviceName dynamically from here
+  const serviceName = 'Child benefit claim';
+
+  if(pageHeading){
+  document.title = `${pageHeading} - ${serviceName} - GOV.UK`
+  } else {
+  document.title = `${serviceName} - GOV.UK`;
+  }
+}


### PR DESCRIPTION
To align with GDS specifications and accessibility guidelines, the Page title, should reflect where the user is in the process.

New helper created to set the page title in format: 
<\<page heading\>> - <\<service name\>> - GOV.UK 

This helper is then called from the application page, whenever the page display state toggles are changed
Also called in the assignment component whenever children update, to reflect the stage heading.
Also called in Viewcontainer component to update the title when on the Claim Summary page for submitted claims.