### PR TITLE
BUG-6496 Data Page Fix

### DIFF
--- a/src/applications/ChildBenefitsClaim/index.tsx
+++ b/src/applications/ChildBenefitsClaim/index.tsx
@@ -82,22 +82,12 @@ export default function ChildBenefitsClaim() {
   function fetchInProgressClaimsData(){
     setLoadingInProgressClaims(true);
     let inProgressClaimsData : any = [];
-    PCore.getDataPageUtils().getDataAsync('D_ClaimantChBAssignmentList', 'root', {OperatorId: operatorId} ).then(resp => {
+    PCore.getDataPageUtils().getDataAsync('D_ClaimantWorkAssignmentChBCases', 'root').then(resp => {
       resp = resp.data.slice(0,10);
       inProgressClaimsData = resp;
-
-
-      const allclaimDetails = Promise.all(resp.map((responseItem) => {
-        return PCore.getDataPageUtils().getPageDataAsync('D_Claim', 'root', {pyID: responseItem.pxRefObjectInsName}, {
-          invalidateCache: true
-         })})).then(data => data);
-
-      allclaimDetails.then( (claims) => {
-        mergeCaseData(inProgressClaimsData, claims);
-        setInprogressClaims(inProgressClaimsData);
-        setLoadingInProgressClaims(false);
-      }
-    )});
+      setInprogressClaims(inProgressClaimsData);
+      setLoadingInProgressClaims(false);
+    });
   }
 
   function cancelAssignment() {

--- a/src/applications/ChildBenefitsClaim/index.tsx
+++ b/src/applications/ChildBenefitsClaim/index.tsx
@@ -62,12 +62,6 @@ export default function ChildBenefitsClaim() {
 
   }
 
-  function mergeCaseData(claimsData: any, data){
-    claimsData.forEach( (claim, index)  => {
-      claimsData[index] = { ...data[index], ...claim  };
-    })
-  };
-
   function closeContainer(){
     setShowPega(false);
     setShowStartPage(false);

--- a/src/components/FlowContainer/helpers.js
+++ b/src/components/FlowContainer/helpers.js
@@ -92,6 +92,7 @@ export const hasAssignments = (pConnect) => {
   const assignments = pConnect.getValue(CASE_INFO.D_CASE_ASSIGNMENTS_RESULTS);
   const childCasesAssignments = getChildCaseAssignments(pConnect);
 
+  // eslint-disable-next-line sonarjs/prefer-single-boolean-return
   if (assignments || childCasesAssignments || isCaseWideLocalAction(pConnect)) {
     return true;
   }

--- a/src/components/FlowContainer/index.tsx
+++ b/src/components/FlowContainer/index.tsx
@@ -128,6 +128,7 @@ export default function FlowContainer(props) {
     if (caseViewMode && caseViewMode === "review") {
       return true;
     }
+    // eslint-disable-next-line sonarjs/prefer-single-boolean-return
     if (caseViewMode && caseViewMode === "perform") {
       return false;
     }
@@ -221,6 +222,7 @@ export default function FlowContainer(props) {
 
     const childCases = ourPConn.getValue(pCoreConstants.CASE_INFO.CHILD_ASSIGNMENTS);
     // const allAssignments = [];
+    // eslint-disable-next-line sonarjs/prefer-single-boolean-return
     if (childCases && childCases.length > 0) {
       return true;
     }

--- a/src/components/MultiStep/index.tsx
+++ b/src/components/MultiStep/index.tsx
@@ -54,6 +54,7 @@ export default function MultiStep(props) {
       }
 
       function _showHLine(index: number): boolean {
+        // eslint-disable-next-line sonarjs/prefer-single-boolean-return
         if (index < arNavigationSteps.length - 1) {
           return true;
         }

--- a/src/components/templates/ClaimsList/index.tsx
+++ b/src/components/templates/ClaimsList/index.tsx
@@ -44,14 +44,14 @@ export default function ClaimsList(props){
   }
 
   function _rowClick(row: any) {
-    const {pzInsKey} = row;
+    const {pzInsKey, pyAssignmentID} = row;
 
     const container = thePConn.getContainerName();
     const target = `root/${container}`;
 
     if( rowClickAction === 'OpenAssignment'){
       const openAssignmentOptions = { containerName: container};
-      PCore.getMashupApi().openAssignment(pzInsKey, target, openAssignmentOptions);
+      PCore.getMashupApi().openAssignment(pyAssignmentID, target, openAssignmentOptions);
     } else if ( rowClickAction === 'OpenCase'){
       PCore.getMashupApi().openCase(pzInsKey, target, {pageName:'SummaryClaim'});
     }

--- a/src/components/templates/ListView/index.tsx
+++ b/src/components/templates/ListView/index.tsx
@@ -728,6 +728,7 @@ export default function ListView(props) {
   function _showFilteredIcon(columnId) {
     for (const filterObj of filterByColumns) {
       if (filterObj['ref'] === columnId) {
+        // eslint-disable-next-line sonarjs/prefer-single-boolean-return
         if (filterObj['containsFilterValue'] !== '') {
           return true;
         }

--- a/src/components/templates/SimpleTable/SimpleTableManual.tsx
+++ b/src/components/templates/SimpleTable/SimpleTableManual.tsx
@@ -476,6 +476,7 @@ export default function SimpleTableManual(props) {
   function _showFilteredIcon(columnId) {
     for (const filterObj of filterByColumns) {
       if (filterObj['ref'] === columnId) {
+        // eslint-disable-next-line sonarjs/prefer-single-boolean-return
         if (filterObj['containsFilterValue'] !== '') {
           return true;
         }


### PR DESCRIPTION
Updates the data page calls to populate the in progress claims list.
No longer requires extra calls to indivudual claim d_pages.


Also added some eslint ignore comments to work around build errors. It seems like the code related to these errors is OOTB so did not want to make changes to the code itself. Unsure why they are being raised now, as do not seem to have been flagged before.