### PR TITLE
bumped to match platform upgraded version of 8.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@material-ui/pickers": "^3.3.10",
-    "@pega/constellationjs": "SDK-8.8.2",
+    "@pega/constellationjs": "SDK-8.8.3",
     "@unicef/material-ui-currency-textfield": "^0.8.6",
     "dayjs": "^1.10.6",
     "dompurify": "^3.0.1",


### PR DESCRIPTION
Pega Platform has been upgraded to 8.8.3 for environments DT1 and STG1 as of 12/07/23
PROD1 will be upgraded on 25/07/23 (accurate as of today)