### PR TITLE
BUG-6674 - Localisation logic added to overridden components

### DIFF
--- a/src/components/AppComponents/LanguageToggle/index.tsx
+++ b/src/components/AppComponents/LanguageToggle/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 declare const PCore: any;
+
 const LanguageToggle = () => {
   const { i18n } = useTranslation();
   let lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
@@ -12,9 +13,14 @@ const LanguageToggle = () => {
     e.preventDefault();
     lang = e.currentTarget.getAttribute('lang');
     setSelectedLang(lang);
-    sessionStorage.setItem('rsdk_locale', `${lang}-GB`);
+    sessionStorage.setItem('rsdk_locale', `${lang}_GB`);
     i18n.changeLanguage(lang);
-    PCore.getEnvironmentInfo().setLocale(`${lang}-GB`);
+    PCore.getEnvironmentInfo().setLocale(`${lang}_GB`);
+
+    //This cleares the generic fields localisation values and attempts to 'refetch' them, as they do not do this
+    // manually after locale is updated
+    PCore.getLocaleUtils().resetLocaleStore();
+    PCore.getLocaleUtils().loadLocaleResources([PCore.getLocaleUtils().GENERIC_BUNDLE_KEY, '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'])
   };
 
   return (

--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -6,11 +6,6 @@ export class Utils {
     document.body.scrollTop = position;
     document.documentElement.scrollTop = position;
   }
-
-  static getComponentFromComponentMap(componentType){
-    return SdkComponentMap.getLocalComponentMap()[componentType] ? SdkComponentMap.getLocalComponentMap()[componentType] : SdkComponentMap.getPegaProvidedComponentMap()[componentType];
-  }
-
 }
 
 export default Utils;

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -4,7 +4,8 @@ import Button from '../../../BaseComponents/Button/Button';
 
 export default function ActionButtons(props) {
   const { arMainButtons, arSecondaryButtons, onButtonPress } = props;
-
+  const localizedVal = PCore.getLocaleUtils().getLocaleValue;
+  const localeCategory = 'Assignment';
   function _onButtonPress(sAction: string, sButtonType: string) {
     onButtonPress(sAction, sButtonType);
   }
@@ -23,7 +24,7 @@ export default function ActionButtons(props) {
               key={mButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {mButton.name}
+              {localizedVal(mButton.name, localeCategory)}
             </Button>
           ) : null
         )}
@@ -40,7 +41,7 @@ export default function ActionButtons(props) {
               key={sButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {sButton.name}
+              {localizedVal(sButton.name, localeCategory)}
             </Button>
           ) : null
         )}
@@ -58,7 +59,7 @@ export default function ActionButtons(props) {
               }}
               key={sButton.actionID}
               attributes={{ type: 'link' }}
-            >{sButton.name}</Button>
+            >{localizedVal(sButton.name, localeCategory)}</Button>
           ) : null
         )}
 

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -32,6 +32,9 @@ export default function Assignment(props) {
   const AssignmentCard = SdkComponentMap.getLocalComponentMap()['AssignmentCard'] ? SdkComponentMap.getLocalComponentMap()['AssignmentCard'] : SdkComponentMap.getPegaProvidedComponentMap()['AssignmentCard'];
 
   const actionsAPI = thePConn.getActionsApi();
+  const localizedVal = PCore.getLocaleUtils().getLocaleValue;
+  const localeCategory = 'Assignment';
+  const localeReference = `${getPConnect().getCaseInfo().getClassName()}!CASE!${getPConnect().getCaseInfo().getName()}`.toUpperCase();
 
   // store off bound functions to above pointers
   const finishAssignment = actionsAPI.finishAssignment.bind(actionsAPI);
@@ -264,9 +267,9 @@ export default function Assignment(props) {
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
           {errorSummary && errorMessages.length > 0 && (
-            <ErrorSummary errors={errorMessages.map(item => item.message)} />
+            <ErrorSummary errors={errorMessages.map(item => localizedVal(item.message, localeCategory, localeReference))} />
           )}
-          {!isOnlyOneField && <h1 className='govuk-heading-l'>{containerName}</h1>}
+          {!isOnlyOneField && <h1 className='govuk-heading-l'>{localizedVal(containerName, '', localeReference)}</h1>}
           <form>
             <AssignmentCard
               getPConnect={getPConnect}

--- a/src/components/override-sdk/infra/FlowContainer/FlowContainer.tsx
+++ b/src/components/override-sdk/infra/FlowContainer/FlowContainer.tsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect, useContext, createElement } from 'react';
 import PropTypes from 'prop-types';
 import { Card, CardHeader, Avatar, Typography } from '@material-ui/core';
 import { Utils } from '@pega/react-sdk-components/lib/components/helpers/utils';
-import AppUtils from '../../../helpers/utils';
 import { Alert } from '@material-ui/lab';
 
 import createPConnectComponent from '@pega/react-sdk-components/lib/bridge/react_pconnect';
@@ -13,6 +12,8 @@ import DayjsUtils from '@date-io/dayjs';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 
 import { addContainerItem, showBanner } from '@pega/react-sdk-components/lib/components/infra/Containers/FlowContainer/helpers';
+
+import { getComponentFromMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
 // import { isEmptyObject } from '@pega/react-sdk-components/lib/components/helpers/common-utils'
 
 // Remove this and use "real" PCore type once .d.ts is fixed (currently shows 3 errors)
@@ -28,7 +29,7 @@ declare const PCore: any;
 export default function FlowContainer(props) {
   const pCoreConstants = PCore.getConstants();
 
-  const Assignment = AppUtils.getComponentFromComponentMap('Assignment');
+  const Assignment =  getComponentFromMap("Assignment");
 
   const { getPConnect, routingInfo } = props;
 

--- a/src/components/override-sdk/infra/View/View.tsx
+++ b/src/components/override-sdk/infra/View/View.tsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 // import { FieldGroup } from "@pega/cosmos-react-core";
 // import { LazyMap as LazyComponentMap } from "../../components_map";
 
-import { SdkComponentMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
-import ErrorBoundary from '@pega/react-sdk-components/lib/components/infra/ErrorBoundary';
+import { getComponentFromMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
+// import ErrorBoundary from '@pega/react-sdk-components/lib/components/infra/ErrorBoundary';
 
 import { getAllFields } from '@pega/react-sdk-components/lib/components/helpers/template-utils';
 
@@ -54,37 +54,7 @@ export default function View(props) {
   //  JA - React SDK not using LazyComponentMap yet
   if (template /* && LazyComponentMap[template] */) {
     // const ViewTemplate = LazyComponentMap[template];
-    let ViewTemplate: any;
-
-    if (SdkComponentMap) {
-      // This is the node_modules version of react_pconnect!
-      const theLocalComponent = SdkComponentMap.getLocalComponentMap()[template];
-      if (theLocalComponent !== undefined) {
-        ViewTemplate = theLocalComponent;
-      } else {
-        const thePegaProvidedComponent = SdkComponentMap.getPegaProvidedComponentMap()[template];
-        if (thePegaProvidedComponent !== undefined) {
-          // console.log(`View component found ${template}: Pega-provided`);
-          ViewTemplate = thePegaProvidedComponent;
-        } else {
-          // eslint-disable-next-line no-console
-          console.error(`View component can't find template type ${template}`);
-          ViewTemplate = ErrorBoundary;
-        }
-      }
-
-      if (template === 'ListView') {
-        // special case for ListView - add in a prop
-        const bInForm = true;
-        props = { ...props, bInForm };
-      }
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(`View: SdkComponentMap expected but not found.`);
-
-      // eslint-disable-next-line no-console
-      console.error(`View: Trying to render an unknown template: ${template}`);
-    }
+    const ViewTemplate = getComponentFromMap(template);
 
     // for debugging/investigation
     // console.log(`View rendering template: ${template}`);

--- a/src/components/override-sdk/template/CaseView/CaseView.tsx
+++ b/src/components/override-sdk/template/CaseView/CaseView.tsx
@@ -51,7 +51,13 @@ export default function CaseView(props) {
     header,
     subheader,
     children,
-    caseInfo: { availableActions = [], availableProcesses = [], hasNewAttachments }
+    caseInfo: {
+      availableActions = [],
+      availableProcesses = [],
+      hasNewAttachments,
+      caseTypeID = '',
+      caseTypeName = ''
+    }
   } = props;
   const currentCaseID = props.caseInfo.ID;
   let isComponentMounted = true;
@@ -63,12 +69,12 @@ export default function CaseView(props) {
   const classes = useStyles();
 
   const editAction = availableActions.find((action) => action.ID === 'pyUpdateCaseDetails');
-
+  const localeKey = `${caseTypeID}!CASE!${caseTypeName}`.toUpperCase();
   /**
    *
    * @param inName the metadata <em>name</em> that will cause a region to be returned
    */
-   function getChildRegionByName(inName: string): any {
+  function getChildRegionByName(inName: string): any {
 
     for (const child of children) {
       const theMetadataType: string = child.props.getPConnect().getRawMetadata()['type'].toLowerCase();
@@ -194,7 +200,7 @@ export default function CaseView(props) {
           <div hidden={true} id="current-caseID">{currentCaseID}</div>
           <Card className={classes.root} >
             <CardHeader className={classes.caseViewHeader}
-              title={<Typography variant="h6" component="div">{header}</Typography>}
+              title={<Typography variant="h6" component="div">{PCore.getLocaleUtils().getLocaleValue(header, '', localeKey)}</Typography>}
               subheader={<Typography variant="body1" component="div" id="caseId">{subheader}</Typography>}
               avatar={
                 <Avatar className={classes.caseViewIconBox} variant="square">

--- a/src/components/override-sdk/template/Details/Details.tsx
+++ b/src/components/override-sdk/template/Details/Details.tsx
@@ -7,6 +7,12 @@ export default function Details(props) {
   const { children, label, context } = props;
   const arFields: Array<any> = [];
 
+  const localizedVal = PCore.getLocaleUtils().getLocaleValue;
+  const localeCategory = 'Assignment';
+  // TODO: may be needed after page heading logic is re-worked (value may need changing to point to correct reference)
+  // const localeReference = `${getPConnect().getCaseInfo().getClassName()}!CASE!${getPConnect().getCaseInfo().getName()}`.toUpperCase();
+
+
   for (const child of children) {
     const theChildPConn = child.props.getPConnect();
     theChildPConn.setInheritedProp('displayMode', 'LABELS_LEFT');
@@ -19,7 +25,7 @@ export default function Details(props) {
     <main className="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
       <div className="govuk-grid-row">
         <div className='govuk-grid-column-two-thirds'>
-          {label && context && <h1 className='govuk-heading-l'>{label}</h1>}
+          {label && context && <h1 className='govuk-heading-l'>{localizedVal(label, localeCategory /*,localeReference*/)} details</h1>}
           <DetailsFields fields={arFields[0]}/>
         </div>
       </div>

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -302,12 +302,9 @@ export default function ChildBenefitsClaim() {
       establishPCoreSubscriptions();
       setShowAppName(true);
 
-      /* const locale = sessionStorage.getItem('rsdk_locale') || 'en-GB';
-      // eslint-disable-next-line no-undef
-      PCore.getEnvironmentInfo().setLocale(locale);
-      // Set default language as english on login
-      sessionStorage.setItem('rsdk_locale', 'en-GB');
-*/
+      //TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
+      PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
+      PCore.getLocaleUtils().loadLocaleResources([PCore.getLocaleUtils().GENERIC_BUNDLE_KEY, '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE']);
       initialRender(renderObj);
 
       operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();


### PR DESCRIPTION
After upgrading to 8.23.11, the pega fixes for localisation were not being pulled through into our overridden components.

This change pulls the relevant code into the overidden components, and also implements some supporting changes to ensure that localisation 'data' is refreshed with language toggle.