### PR TITLE
Bug 6390 - Additional support for autocomplete attributes

### DIFF
--- a/src/components/BaseComponents/DateInput/DateInput.tsx
+++ b/src/components/BaseComponents/DateInput/DateInput.tsx
@@ -6,7 +6,7 @@ import FieldSet from '../FormGroup/FieldSet'
 
 export default function DateInput(props){
 
-  const {name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, testId, inputProps={}} = props;
+  const { name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, testId, inputProps={}, autoComplete} = props;
   let {errorProps} = props;
   const { t } = useTranslation();
 
@@ -43,6 +43,14 @@ export default function DateInput(props){
     inputProps["aria-describedby"] = describedbyIds;
   }
 
+  let acDay = "";
+  let acMonth = "";
+  let acYear = "";
+  if(autoComplete === "bday"){
+    acDay = "bday-day";
+    acMonth = "bday-month";
+    acYear = "bday-year";
+  }
 
   const extraProps= {testProps:{'data-test-id':testId}};
 
@@ -54,7 +62,8 @@ export default function DateInput(props){
             <input className={[inputClasses, widthClass(2), errorClass(errorProps?.specificError?.day)].join(' ')}
               id={`${name}-day`} name={`${name}-day`} type="text"
               inputMode="numeric" value={value?.day}
-              onChange={onChangeDay} />
+              onChange={onChangeDay}
+              autoComplete={acDay || undefined}/>
           </FormGroup>
         </div>
         <div className="govuk-date-input__item">
@@ -63,6 +72,7 @@ export default function DateInput(props){
               id={`${name}-month`} name={`${name}-month`} type="text"
               inputMode="numeric" value={value?.month}
               onChange={onChangeMonth}
+              autoComplete={acMonth || undefined}
             />
           </FormGroup>
         </div>
@@ -72,6 +82,7 @@ export default function DateInput(props){
               id={`${name}-year`} name={`${name}-year`} type="text"
               inputMode="numeric" value={value?.year}
               onChange={onChangeYear}
+              autoComplete={acYear || undefined}
             />
           </FormGroup>
         </div>

--- a/src/components/override-sdk/field/Date/Date.tsx
+++ b/src/components/override-sdk/field/Date/Date.tsx
@@ -19,7 +19,8 @@ export default function Date(props) {
     helperText,
     readOnly,
     name,
-    testId
+    testId,
+    configAlternateDesignSystem
   } = props;
   const pConn = getPConnect();
 
@@ -113,6 +114,10 @@ export default function Date(props) {
   }
 
   const extraProps = { testProps: { 'data-test-id': testId } };
+
+  if (configAlternateDesignSystem?.autocomplete) {
+    extraProps['autoComplete'] = configAlternateDesignSystem.autocomplete;
+  }
 
   return (
     <DateInput

--- a/src/components/override-sdk/field/Date/config-ext.json
+++ b/src/components/override-sdk/field/Date/config-ext.json
@@ -6,5 +6,22 @@
   "subtype": "Date",
   "componentKey" : "Date",
   "properties": [
+    {
+      "format": "SELECT",
+      "name": "autocomplete",
+      "label": "Autocomplete attribute",
+      "defaultValue": "",
+      "placeholder": "Does this field require an autocomplete value assigned to it?",
+      "required": false,
+      "helperText": "Autocomplete attributes allow browsers to complete information which has been provided before on any site.  This assists users when completing forms.  Please add the relevant autocomplete value if required.",
+      "source": [
+        { "key": "tel", "value": "tel" },
+        { "key": "tel-area-code", "value": "tel-area-code" },
+        { "key": "tel-country-code", "value": "tel-country-code" },
+        { "key": "tel-external", "value": "tel-external" },
+        { "key": "tel-local", "value": "tel-local" },
+        { "key": "tel-national", "value": "tel-national" }
+      ]
+    }
   ]
 }

--- a/src/components/override-sdk/field/Date/config-ext.json
+++ b/src/components/override-sdk/field/Date/config-ext.json
@@ -15,12 +15,10 @@
       "required": false,
       "helperText": "Autocomplete attributes allow browsers to complete information which has been provided before on any site.  This assists users when completing forms.  Please add the relevant autocomplete value if required.",
       "source": [
-        { "key": "tel", "value": "tel" },
-        { "key": "tel-area-code", "value": "tel-area-code" },
-        { "key": "tel-country-code", "value": "tel-country-code" },
-        { "key": "tel-external", "value": "tel-external" },
-        { "key": "tel-local", "value": "tel-local" },
-        { "key": "tel-national", "value": "tel-national" }
+        { "key": "bday", "value": "bday" },
+        { "key": "bday-day", "value": "bday-day" },
+        { "key": "bday-month", "value": "bday-month" },
+        { "key": "bday-year", "value": "bday-year" }
       ]
     }
   ]

--- a/src/components/override-sdk/field/Phone/Phone.tsx
+++ b/src/components/override-sdk/field/Phone/Phone.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import TextInput from '../TextInput';
 
+interface InputProps {
+  type: string;
+  onChange: Function;
+  autoComplete?: string; // Make autocomplete optional
+}
+
 export default function Phone(props) {
   const {
     onChange,
+    autocomplete
   } = props;
-
-  /*
-  let testProp = {};
-  testProp = {
-    'data-test-id': testId
-  };
-  */
 
   const handleChange = inputVal => {
     let phoneValue = inputVal && inputVal.replace(/\D+/g, '');
@@ -19,19 +19,21 @@ export default function Phone(props) {
     onChange({ value: phoneValue });
   };
 
+  const inputProps: InputProps = {
+    type: 'tel',
+    onChange: handleChange,
+  };
+
+  // Conditionally add the autocomplete prop if it's not blank
+  if (autocomplete !== '') {
+    inputProps.autoComplete = autocomplete;
+  }
+
   return (
 
     <TextInput
       {...props}
-      inputProps={{
-          type:'tel',
-          onChange:handleChange,
-          /*
-            TODO enable if always relevant
-            autocomplete="tel"
-          */
-        }
-      }
+      inputProps={inputProps}
     />
   );
 }


### PR DESCRIPTION
Support for configuration of autocomplete attributes in Pega.

- Updated phone component to take and assign the autocomplete attribute.
- Updated overriden Date and base DateInput components to allow support of autocomplete attributes.  Slightly different to other input fields in that this one detects the pass of "bday" autocomplete attribute - if it's found, then the three appropriate autocomplete attributes are added to day, month and year input fields.

There is a Pega branch which needs to be merged, but this IS NOT a hard dependency