### PR TITLE
BUG-6543 - Fix alignment issues on CYA page

### DIFF
--- a/src/components/helpers/HMRCAppContext.tsx
+++ b/src/components/helpers/HMRCAppContext.tsx
@@ -1,7 +1,5 @@
 import {createContext} from 'react';
 
-
-
 const DefaultFormContext = createContext({
   // Is this Default Form set to display as single question?
   displayAsSingleQuestion: false,
@@ -11,5 +9,8 @@ const DefaultFormContext = createContext({
   OverrideLabelValue: ''
 });
 
+const ReadOnlyDefaultFormContext = createContext({
+  hasBeenWrapped: false
+})
 
-export default DefaultFormContext;
+export {DefaultFormContext, ReadOnlyDefaultFormContext}

--- a/src/components/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/components/helpers/hooks/QuestionDisplayHooks.ts
@@ -1,5 +1,5 @@
 import {useContext} from 'react';
-import DefaultFormContext from '../../helpers/HMRCAppContext';
+import {DefaultFormContext} from '../../helpers/HMRCAppContext';
 /**
  * Helper hook for handling instances where there is only one field presented in the current view.
  * Returns a boolean indicating whether or not there is only one field to display in the current context

--- a/src/components/override-sdk/template/FieldGroupTemplate/FieldGroupTemplate.tsx
+++ b/src/components/override-sdk/template/FieldGroupTemplate/FieldGroupTemplate.tsx
@@ -111,6 +111,12 @@ export default function Group(props) {
       </>);
     }
 
+    if(readOnly){
+      return (<>
+        {children}
+      </>)
+    }
+
     return (<>
       {heading && <div id='heading' className='govuk-body'>{heading}</div>}
       {instructions && instructions !== 'none' && <div id='instructions' className='govuk-body'><InstructionComp htmlString={instructions} /></div>}


### PR DESCRIPTION
Alignment issues on the CYA pages were being caused by nested <dl> elements being generated.

This fix adds a new context to use in read only Default form components, ensuring any nested default forms will not render a <dl> component if they have already been wrapped.