### PR TITLE
BUG-7031 - Handling of Instruction Text for Single Question pages

### DIFF
--- a/src/components/BaseComponents/FormGroup/FieldSet.tsx
+++ b/src/components/BaseComponents/FormGroup/FieldSet.tsx
@@ -1,14 +1,18 @@
 
-import React, {useState, useEffect } from 'react';
+import React, {useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import ConditionalWrapper from '../../helpers/formatters/ConditionalWrapper';
 import HintTextComponent from '../../helpers/formatters/ParsedHtml';
+import { DefaultFormContext } from '../../helpers/HMRCAppContext';
+import InstructionComp from '../../helpers/formatters/ParsedHtml';
 
 export default function FieldSet({legendIsHeading=true, label, name, errorText, hintText, children, fieldsetElementProps, testProps}){
   const[ErrorMessage,setErrorMessage] = useState(errorText);
 
-  useEffect(()=>{
+  const {instructionText} = useContext(DefaultFormContext);
+  
 
+  useEffect(()=>{
     if(errorText){
     setErrorMessage(errorText)
     }
@@ -33,9 +37,16 @@ export default function FieldSet({legendIsHeading=true, label, name, errorText, 
             condition={legendIsHeading}
             wrapper={ child => {
                       return (
-                      <h1 className="govuk-fieldset__heading">
-                        {child}
-                      </h1>)}
+                      <>
+                        <h1 className="govuk-fieldset__heading">                        
+                          {child}
+                        </h1>
+                        {instructionText && (
+                          <p id='instructions' className='govuk-body'>
+                            <InstructionComp htmlString={instructionText} />
+                          </p>
+                        )}                      
+                      </>)}
                     }
             childrenToWrap={label}
           />

--- a/src/components/helpers/HMRCAppContext.tsx
+++ b/src/components/helpers/HMRCAppContext.tsx
@@ -6,7 +6,10 @@ const DefaultFormContext = createContext({
   // What is the name of this Default Form (should be same as name pushed to HMRCAppContext SingleQuestionDisplayDFStack)
   DFName: -1,
   // Holds assignment name incase needed for single page label
-  OverrideLabelValue: ''
+  OverrideLabelValue: '',
+
+  //Holds DefaultForm level instruction text for use in field set instruction blocks
+  instructionText: ''
 });
 
 const ReadOnlyDefaultFormContext = createContext({

--- a/src/components/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/components/helpers/hooks/QuestionDisplayHooks.ts
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import {DefaultFormContext} from '../../helpers/HMRCAppContext';
 /**
  * Helper hook for handling instances where there is only one field presented in the current view.
@@ -8,33 +8,41 @@ import {DefaultFormContext} from '../../helpers/HMRCAppContext';
 /* Retaining this code for future change in implementation of single question pages. */
 
 
-export default function useIsOnlyField(callerDisplayOrder = null){
+export default function useIsOnlyField(callerDisplayOrder = null, refreshTrigger = null){
     const DFContext = useContext(DefaultFormContext);
-    const returnObj = {isOnlyField: false, overrideLabel: ''};
+    const defaultOnlyFieldDetails = {isOnlyField: false, overrideLabel: ''};
+    const [onlyFieldDetails, setOnlyFieldDetails] = useState({isOnlyField: false, overrideLabel: ''})
+    
+
+    useEffect(() => {
 
     if (PCore.getStoreValue('displayAsSingleQuestion', '', 'app') && DFContext.DFName === -1){
-        returnObj.isOnlyField = true;
-        return returnObj;
+        defaultOnlyFieldDetails.isOnlyField = true;
+        setOnlyFieldDetails(defaultOnlyFieldDetails);
     }
+    
 
     // Checks to see if the closest parent default form of the current element is in the SingleQuestionDisplayDFStack
     // If it is, display this element as if it's a single field IF it's the first element in the form. (Driven by the display order it has been given)
     if(DFContext.displayAsSingleQuestion){
-        returnObj.isOnlyField = callerDisplayOrder === "0" ? DFContext.displayAsSingleQuestion : false;
+        defaultOnlyFieldDetails.isOnlyField = callerDisplayOrder === "0" ? DFContext.displayAsSingleQuestion : false;
     }
     // Otherwise, use the Assignment context's singleQuestion page value, to fall back to the original logic (checking number of editable fields);
     else {
-        returnObj.overrideLabel = DFContext.OverrideLabelValue;
+        defaultOnlyFieldDetails.overrideLabel = DFContext.OverrideLabelValue;
         const editableFieldsCount = PCore.getFormUtils().getEditableFields(PCore.getContainerUtils().getActiveContainerItemContext('app/primary_1/workarea')).length;
 
         if(editableFieldsCount === 1){
-            returnObj.isOnlyField = true;
+            defaultOnlyFieldDetails.isOnlyField = true;
         } else if (DFContext.DFName !== -1) {
-            returnObj.isOnlyField = false;
+            defaultOnlyFieldDetails.isOnlyField = false;
         } else {
-            returnObj.isOnlyField = PCore.getStoreValue('displayAsSingleQuestion', '', 'app');
+            defaultOnlyFieldDetails.isOnlyField = !!PCore.getStoreValue('displayAsSingleQuestion', '', 'app');
         }
 
     }
-    return returnObj;
+    setOnlyFieldDetails(defaultOnlyFieldDetails);
+    }, [refreshTrigger])
+    
+    return onlyFieldDetails;
 }

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -46,7 +46,7 @@ export default function Assignment(props) {
   // const showPage = actionsAPI.showPage.bind(actionsAPI);
 
 
-  const isOnlyField  = useIsOnlyField().isOnlyField;
+  const isOnlyFieldDetails  = useIsOnlyField(null, children);//.isOnlyField;
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
 
@@ -274,7 +274,7 @@ export default function Assignment(props) {
             {errorSummary && errorMessages.length > 0 && (
               <ErrorSummary errors={errorMessages.map(item => localizedVal(item.message, localeCategory, localeReference))} />
             )}
-            {(!isOnlyField || containerName.toLowerCase().includes('check your answer')) && <h1 className='govuk-heading-l'>{localizedVal(containerName, '', localeReference)}</h1>}
+            {(!isOnlyFieldDetails.isOnlyField || containerName.toLowerCase().includes('check your answer')) && <h1 className='govuk-heading-l'>{localizedVal(containerName, '', localeReference)}</h1>}
             <form>
               <AssignmentCard
                 getPConnect={getPConnect}


### PR DESCRIPTION
Some pages, with a single question, were seeing their instruction text (provided at Default Form level) displaying above the page heading.

To resolve this, have extended single question page logic and updated Default Form component to pass the form instructions through to a field for display, IF there is only a single question on the page.