### PR TITLE
BUG-7031 - Add page display handling for pages with read only information display

### DIFF
--- a/src/components/custom-sdk/template/MimicASentence/MimicASentence.tsx
+++ b/src/components/custom-sdk/template/MimicASentence/MimicASentence.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, Fragment } from 'react';
+import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
 import PropTypes from 'prop-types';
 
 // Duplicated runtime code from Constellation Design System Component
@@ -9,6 +10,8 @@ export default function HmrcOdxMimicASentence(props) {
   const { children } = props;
 
   const [formElms, setFormElms] = useState<Array<React.ReactElement>>([]);
+
+  registerNonEditableField();
 
   useEffect(() => {
     const elms:Array<React.ReactElement> = [];

--- a/src/components/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/components/helpers/hooks/QuestionDisplayHooks.ts
@@ -30,10 +30,11 @@ export default function useIsOnlyField(callerDisplayOrder = null, refreshTrigger
     // Otherwise, use the Assignment context's singleQuestion page value, to fall back to the original logic (checking number of editable fields);
     else {
         defaultOnlyFieldDetails.overrideLabel = DFContext.OverrideLabelValue;
+        const pageHasNoneEditableField = PCore.getStoreValue('pageHasNonEdtiableField', '', 'app');
         const context =  PCore.getContainerUtils().getActiveContainerItemName(`${PCore.getConstants().APP.APP}/primary`);
         const editableFieldsCount = PCore.getFormUtils().getEditableFields(PCore.getContainerUtils().getActiveContainerItemContext(`${context}/workarea`)).length;
 
-        if(editableFieldsCount === 1){
+        if(editableFieldsCount === 1 && !pageHasNoneEditableField){
             defaultOnlyFieldDetails.isOnlyField = true;
         } else if (DFContext.DFName !== -1) {
             defaultOnlyFieldDetails.isOnlyField = false;
@@ -47,3 +48,24 @@ export default function useIsOnlyField(callerDisplayOrder = null, refreshTrigger
     
     return onlyFieldDetails;
 }
+
+function registerNonEditableField(nonEditableCondition = true) { 
+    useEffect(() => {
+        if(nonEditableCondition && !PCore.getStoreValue('pageHasNonEdtiableField', '', 'app')){      
+            PCore.getStore().dispatch({type:'SET_PROPERTY', payload:{
+            "reference": "pageHasNonEdtiableField",
+            "value": true,
+            "context": "app",
+            "isArrayDeepMerge": true}})
+            return () => {
+            PCore.getStore().dispatch({type:'SET_PROPERTY', payload:{
+                "reference": "pageHasNonEdtiableField",
+                "value": false,
+                "context": "app",
+                "isArrayDeepMerge": true}})
+            }
+        }
+    }, [])
+}
+ 
+export { registerNonEditableField }

--- a/src/components/override-sdk/field/TextInput/TextInput.tsx
+++ b/src/components/override-sdk/field/TextInput/TextInput.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import GDSTextInput from '../../../BaseComponents/TextInput/TextInput';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
 
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 
@@ -23,6 +24,8 @@ export default function TextInput(props) {
   } = props;
 
   const[errorMessage,setErrorMessage] = useState(validatemessage);
+
+  registerNonEditableField(!!disabled);
 
   useEffect(()=>{
 


### PR DESCRIPTION
Text and mimic a sentence fields now register to the global state if they are 'disabled' - (as they are for check address and check name, to allow the only field display logic to correctly display the page heading.