### PR TITLE
BUG-7216 - Remove duplicated instruction text

### DIFF
--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -247,7 +247,7 @@ export default function DefaultForm(props) {
           displayAsSingleQuestion: configAlternateDesignSystem?.hidePageLabel,
           DFName: props.localeReference,
           OverrideLabelValue: containerName, 
-          instructionText: getFormattedInstructionText() as string
+          instructionText: (instructionExists && !singleQuestionPage) ? null : getFormattedInstructionText() as string
         }}>
 
         {instructionExists && !singleQuestionPage && (


### PR DESCRIPTION
Updates Default Form instruction text logic to only 'pass-through' instruction text if it has not already been display in Default form