### PR TITLE
 Bug 7009 - 2 - Default forms handle missing assignment info 

### DIFF
--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -15,7 +15,10 @@ export default function DefaultForm(props) {
   const {instructionText: passedThroughInstructionText} = useContext(DefaultFormContext);
 
   const [declaration, setDeclaration] = useState({text1: '', warning1: ''});
-  const containerName = getPConnect().getDataObject().caseInfo?.assignments[0]?.name;
+  let  containerName = null;
+  if(getPConnect().getDataObject().caseInfo?.assignments){
+    containerName = getPConnect().getDataObject().caseInfo?.assignments[0].name;
+  }
 
   const { t } = useTranslation();
   let cssClassHook = "";


### PR DESCRIPTION
To resolve an issue where all summary fields for legacy cases hit an error due to no assignment info in case info, added handling for this situation