### PR TITLE
BUG-7023 Missing title on declaration page

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -278,7 +278,7 @@ export default function Assignment(props) {
             {errorSummary && errorMessages.length > 0 && (
               <ErrorSummary errors={errorMessages.map(item => localizedVal(item.message, localeCategory, localeReference))} />
             )}
-            {(!isOnlyFieldDetails.isOnlyField || containerName.toLowerCase().includes('check your answer')) && <h1 className='govuk-heading-l'>{localizedVal(containerName, '', localeReference)}</h1>}
+            {(!isOnlyFieldDetails.isOnlyField || containerName.toLowerCase().includes('check your answer') || containerName.toLowerCase().includes('declaration')) && <h1 className='govuk-heading-l'>{localizedVal(containerName, '', localeReference)}</h1>}
             <form>
               <AssignmentCard
                 getPConnect={getPConnect}


### PR DESCRIPTION
Used an identifier to make sure the title shows when the declaration is loaded. 