### PR TITLE
Bug 7290 Errors for declaration checkboxes not appearing

### DIFF
--- a/src/components/override-sdk/field/Checkbox/Checkbox.tsx
+++ b/src/components/override-sdk/field/Checkbox/Checkbox.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import GDSCheckbox from '../../../BaseComponents/Checkboxes/Checkbox';
 // import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks'
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+import { DefaultFormContext }  from '../../../helpers/HMRCAppContext';
 
 export default function CheckboxComponent(props) {
   const {
     getPConnect,
     inputProps,
-   // validatemessage,
+    validatemessage,
     hintText,
     readOnly,
     value
@@ -53,10 +54,30 @@ export default function CheckboxComponent(props) {
     handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
   };
 
+  const formContext = useContext(DefaultFormContext);
+
   return (
     <>    
       {exclusiveOption && <div className="govuk-checkboxes__divider">or</div>}
-      <GDSCheckbox
+      {formContext.OverrideLabelValue === 'Declaration' ? (
+        <div className={`govuk-form-group ${validatemessage ? 'govuk-form-group--error' : ''}`}>
+          {validatemessage && <p id={`${name}-error`} className="govuk-error-message">
+            <span className="govuk-visually-hidden">Error:</span> {validatemessage}
+          </p>}
+          <GDSCheckbox
+          item={{checked: value, label: caption, readOnly:false, hintText}}
+          index={index}
+          name={name}
+          inputProps={...inputProps}
+          onChange={(evt) => {
+            handleChange(evt)
+            exclusiveOptionChangeHandler();                
+          }}
+          key={name}
+              />
+        </div>
+      ) : (
+        <GDSCheckbox
         item={{checked: value, label: caption, readOnly:false, hintText}}
         index={index}
         name={name}
@@ -67,6 +88,7 @@ export default function CheckboxComponent(props) {
         }}
         key={name}
             />
+      )}
     </>
   );
 }

--- a/src/components/override-sdk/field/Checkbox/Checkbox.tsx
+++ b/src/components/override-sdk/field/Checkbox/Checkbox.tsx
@@ -59,6 +59,8 @@ export default function CheckboxComponent(props) {
   return (
     <>    
       {exclusiveOption && <div className="govuk-checkboxes__divider">or</div>}
+
+      {/* If its the declaration view then group the checkboxes separately so the error message is assigned correctly */}
       {formContext.OverrideLabelValue === 'Declaration' ? (
         <div className={`govuk-form-group ${validatemessage ? 'govuk-form-group--error' : ''}`}>
           {validatemessage && <p id={`${name}-error`} className="govuk-error-message">

--- a/src/components/override-sdk/field/Checkbox/Checkbox.tsx
+++ b/src/components/override-sdk/field/Checkbox/Checkbox.tsx
@@ -6,6 +6,8 @@ import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDis
 import { DefaultFormContext }  from '../../../helpers/HMRCAppContext';
 
 export default function CheckboxComponent(props) {
+  const {OverrideLabelValue} = useContext(DefaultFormContext);
+  
   const {
     getPConnect,
     inputProps,
@@ -54,14 +56,12 @@ export default function CheckboxComponent(props) {
     handleEvent(actionsApi, 'changeNblur', propName, event.target.checked);
   };
 
-  const formContext = useContext(DefaultFormContext);
-
   return (
     <>    
       {exclusiveOption && <div className="govuk-checkboxes__divider">or</div>}
 
       {/* If its the declaration view then group the checkboxes separately so the error message is assigned correctly */}
-      {formContext.OverrideLabelValue === 'Declaration' ? (
+      {OverrideLabelValue === 'Declaration' ? (
         <div className={`govuk-form-group ${validatemessage ? 'govuk-form-group--error' : ''}`}>
           {validatemessage && <p id={`${name}-error`} className="govuk-error-message">
             <span className="govuk-visually-hidden">Error:</span> {validatemessage}

--- a/src/components/override-sdk/field/Checkbox/Checkbox.tsx
+++ b/src/components/override-sdk/field/Checkbox/Checkbox.tsx
@@ -61,7 +61,7 @@ export default function CheckboxComponent(props) {
       {exclusiveOption && <div className="govuk-checkboxes__divider">or</div>}
 
       {/* If its the declaration view then group the checkboxes separately so the error message is assigned correctly */}
-      {OverrideLabelValue === 'Declaration' ? (
+      {OverrideLabelValue.trim().toLowerCase() === 'declaration' ? (
         <div className={`govuk-form-group ${validatemessage ? 'govuk-form-group--error' : ''}`}>
           {validatemessage && <p id={`${name}-error`} className="govuk-error-message">
             <span className="govuk-visually-hidden">Error:</span> {validatemessage}


### PR DESCRIPTION
Errors for declaration checkboxes not appearing have used the HMRCAppContext to identify the view by name, then I'm wrapping the checkboxes in their own individual groups. This means we get the red border and the error message is assigned correctly. 