### PR TITLE
US-9579 RichText Component handling (for use to display process advice with links)

### DIFF
--- a/sdk-local-component-map.js
+++ b/sdk-local-component-map.js
@@ -22,6 +22,7 @@ import MimicASentence from './src/components/custom-sdk/template/MimicASentence/
 import HmrcOdxGdsInfoPanel from './src/components/custom-sdk/template/HMRC_ODX_GDSInfoPanel/';
 import HmrcOdxGdsSummaryCard from './src/components/custom-sdk/template/HMRC_ODX_GDSSummaryCard/';
 import HmrcOdxGdsButton from './src/components/custom-sdk/field/HMRC_ODX_GDSButton/';
+import RichText from './src/components/override-sdk/field/RichText';
 /*import end - DO NOT REMOVE*/
 
 // localSdkComponentMap is the JSON object where we'll store the components that are
@@ -51,6 +52,7 @@ const localSdkComponentMap = {
   "HMRC_ODX_GDSInfoPanel" : HmrcOdxGdsInfoPanel,
   "HMRC_ODX_GDSSummaryCard" : HmrcOdxGdsSummaryCard,
   "HMRC_ODX_GDSButton" : HmrcOdxGdsButton,
+  "RichText": RichText
 /*map end - DO NOT REMOVE*/
 };
 

--- a/src/components/helpers/formatters/ParsedHtml.tsx
+++ b/src/components/helpers/formatters/ParsedHtml.tsx
@@ -25,6 +25,34 @@ export default function InstructionComp({htmlString}) {
     return htmlString;
   }
 
+  // Configure DOMPurify to retain target=_blank attributes on html, adding noreferrer and noopener rel attributes for added safety
+  const appendSecureRelValue = (rel) => {
+    const attributes = new Set(rel ? rel.toLowerCase().split(' ') : []);
+  
+    attributes.add('noopener');
+    attributes.add('noreferrer');
+  
+    return Array.from(attributes).join(' ');
+  };
+  const TEMPORARY_ATTRIBUTE = 'data-temp-href-target';
+
+  DOMPurify.addHook('beforeSanitizeAttributes', (node) => {
+    if (node.tagName === 'A' && node.hasAttribute('target')) {
+      node.setAttribute(TEMPORARY_ATTRIBUTE, node.getAttribute('target'));
+    }
+  });
+
+  DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+    if (node.tagName === 'A' && node.hasAttribute(TEMPORARY_ATTRIBUTE)) {
+      node.setAttribute('target', node.getAttribute(TEMPORARY_ATTRIBUTE));
+      node.removeAttribute(TEMPORARY_ATTRIBUTE);
+      if (node.getAttribute('target') === '_blank') {
+        const rel = node.getAttribute('rel');
+        node.setAttribute('rel', appendSecureRelValue(rel));
+      }
+    }
+  });
+
   const cleanHTML = DOMPurify.sanitize(htmlString,
     { USE_PROFILES: { html: true } });
   return <>{parse(cleanHTML)}</>;

--- a/src/components/helpers/hooks/QuestionDisplayHooks.ts
+++ b/src/components/helpers/hooks/QuestionDisplayHooks.ts
@@ -11,8 +11,7 @@ import {DefaultFormContext} from '../../helpers/HMRCAppContext';
 export default function useIsOnlyField(callerDisplayOrder = null, refreshTrigger = null){
     const DFContext = useContext(DefaultFormContext);
     const defaultOnlyFieldDetails = {isOnlyField: false, overrideLabel: ''};
-    const [onlyFieldDetails, setOnlyFieldDetails] = useState({isOnlyField: false, overrideLabel: ''})
-    
+    const [onlyFieldDetails, setOnlyFieldDetails] = useState({isOnlyField: false, overrideLabel: ''})    
 
     useEffect(() => {
 
@@ -21,7 +20,6 @@ export default function useIsOnlyField(callerDisplayOrder = null, refreshTrigger
         setOnlyFieldDetails(defaultOnlyFieldDetails);
     }
     
-
     // Checks to see if the closest parent default form of the current element is in the SingleQuestionDisplayDFStack
     // If it is, display this element as if it's a single field IF it's the first element in the form. (Driven by the display order it has been given)
     if(DFContext.displayAsSingleQuestion){

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -1,0 +1,99 @@
+import React, { useRef } from 'react';
+import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
+
+import { getComponentFromMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
+import type { PConnFieldProps } from '@pega/react-sdk-components/lib/types/PConnProps'
+import InstructionComp from '../../../helpers/formatters/ParsedHtml';
+import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
+
+interface RichTextProps extends PConnFieldProps {
+  // If any, enter additional props that only exist on TextArea here
+  additionalProps?: object;
+}
+
+export default function RichText(props: RichTextProps) {
+  // Get emitted components from map (so we can get any override that may exist)
+  //const FieldValueList = getComponentFromMap('FieldValueList');
+  //const RichTextEditor = getComponentFromMap('RichTextEditor');
+
+  registerNonEditableField(true);
+
+  const { getPConnect, value, placeholder, validatemessage, label, hideLabel, helperText, testId, displayMode, additionalProps } = props;
+  const pConn = getPConnect();
+  const editorRef: any = useRef(null);
+
+  let { readOnly, required, disabled } = props;
+  [readOnly, required, disabled] = [readOnly, required, disabled].map((prop) => prop === true || (typeof prop === 'string' && prop === 'true'));
+
+  const helperTextToDisplay = validatemessage || helperText;
+
+  /*if (displayMode === 'LABELS_LEFT') {
+    return <FieldValueList name={hideLabel ? '' : label} value={value} />;
+  }
+
+  if (displayMode === 'STACKED_LARGE_VAL') {
+    return <FieldValueList name={hideLabel ? '' : label} value={value} variant="stacked" />;
+  }*/
+
+  let richTextComponent;
+
+  if (readOnly) {
+    // Rich Text read-only component    
+    richTextComponent = (
+      <>
+        <InstructionComp htmlString={value}></InstructionComp>
+      </>
+    );
+  } else {
+    // Rich Text editable component
+    const actionsApi = pConn.getActionsApi();
+    let status = '';
+    if (validatemessage !== '') {
+      status = 'error';
+    }
+    const handleChange = () => {
+      if (status === 'error') {
+        const property = pConn.getStateProps()["value"];
+        pConn.clearErrorMessages({
+          property,
+          category: '',
+          context: ''
+        });
+      }
+    };
+
+    const handleBlur = () => {
+      if (editorRef.current) {
+        const editorValue = editorRef.current.getContent({ format: 'html' });
+        const property = pConn.getStateProps()["value"];
+        handleEvent(actionsApi, 'changeNblur', property, editorValue);
+      }
+    };
+
+
+    // Component returns value of field, (parsed if it is html) as readonly block - as no requirement for editable RichText as of US-9579
+    richTextComponent = (        
+      <InstructionComp htmlString={value}></InstructionComp>        
+    );
+    // TODO - Add implementation of Editable Rich Text component (Unsure whether this would simply be text area, or full richtext)
+    /* richTextComponent = (        
+      <RichTextEditor
+        {...additionalProps}
+        label={label}
+        labelHidden={hideLabel}
+        info={helperTextToDisplay}
+        defaultValue={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        required={required}
+        testId={testId}
+        ref={editorRef}
+        error={status === 'error'}
+        onBlur={handleBlur}
+        onChange={handleChange}
+      />
+    ); */
+  }
+
+  return richTextComponent;
+}

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -1,7 +1,5 @@
-import React, { useRef } from 'react';
-import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
-
-import { getComponentFromMap } from '@pega/react-sdk-components/lib/bridge/helpers/sdk_component_map';
+import React from 'react';
+// import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 import type { PConnFieldProps } from '@pega/react-sdk-components/lib/types/PConnProps'
 import InstructionComp from '../../../helpers/formatters/ParsedHtml';
 import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
@@ -12,28 +10,21 @@ interface RichTextProps extends PConnFieldProps {
 }
 
 export default function RichText(props: RichTextProps) {
-  // Get emitted components from map (so we can get any override that may exist)
-  //const FieldValueList = getComponentFromMap('FieldValueList');
-  //const RichTextEditor = getComponentFromMap('RichTextEditor');
-
   registerNonEditableField(true);
 
-  const { getPConnect, value, placeholder, validatemessage, label, hideLabel, helperText, testId, displayMode, additionalProps } = props;
-  const pConn = getPConnect();
-  const editorRef: any = useRef(null);
+  const { value } = props;
+ 
 
   let { readOnly, required, disabled } = props;
   [readOnly, required, disabled] = [readOnly, required, disabled].map((prop) => prop === true || (typeof prop === 'string' && prop === 'true'));
 
-  const helperTextToDisplay = validatemessage || helperText;
-
-  /*if (displayMode === 'LABELS_LEFT') {
+  /* if (displayMode === 'LABELS_LEFT') {
     return <FieldValueList name={hideLabel ? '' : label} value={value} />;
   }
 
   if (displayMode === 'STACKED_LARGE_VAL') {
     return <FieldValueList name={hideLabel ? '' : label} value={value} variant="stacked" />;
-  }*/
+  } */
 
   let richTextComponent;
 
@@ -46,7 +37,7 @@ export default function RichText(props: RichTextProps) {
     );
   } else {
     // Rich Text editable component
-    const actionsApi = pConn.getActionsApi();
+    /* const actionsApi = pConn.getActionsApi();
     let status = '';
     if (validatemessage !== '') {
       status = 'error';
@@ -68,7 +59,7 @@ export default function RichText(props: RichTextProps) {
         const property = pConn.getStateProps()["value"];
         handleEvent(actionsApi, 'changeNblur', property, editorValue);
       }
-    };
+    }; */
 
 
     // Component returns value of field, (parsed if it is html) as readonly block - as no requirement for editable RichText as of US-9579

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -7,12 +7,13 @@ import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplay
 interface RichTextProps extends PConnFieldProps {
   // If any, enter additional props that only exist on TextArea here
   additionalProps?: object;
+  name: string;
 }
 
 export default function RichText(props: RichTextProps) {
   registerNonEditableField(true);
 
-  const { value } = props;
+  const { value, name } = props;
  
 
   let { readOnly, required, disabled } = props;
@@ -31,9 +32,9 @@ export default function RichText(props: RichTextProps) {
   if (readOnly) {
     // Rich Text read-only component    
     richTextComponent = (
-      <>
+      <div id={`${name}-hint`} className="govuk-hint">      
         <InstructionComp htmlString={value}></InstructionComp>
-      </>
+      </div>
     );
   } else {
     // Rich Text editable component
@@ -64,7 +65,9 @@ export default function RichText(props: RichTextProps) {
 
     // Component returns value of field, (parsed if it is html) as readonly block - as no requirement for editable RichText as of US-9579
     richTextComponent = (        
-      <InstructionComp htmlString={value}></InstructionComp>        
+      <div id={`${name}-hint`} className="govuk-hint">      
+        <InstructionComp htmlString={value}></InstructionComp>
+      </div>        
     );
     // TODO - Add implementation of Editable Rich Text component (Unsure whether this would simply be text area, or full richtext)
     /* richTextComponent = (        

--- a/src/components/override-sdk/field/RichText/index.tsx
+++ b/src/components/override-sdk/field/RichText/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RichText';

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -26,11 +26,9 @@ export default function Assignment(props) {
   const { getPConnect, children, itemKey, isCreateStage } = props;
   const thePConn = getPConnect();
   const [arSecondaryButtons, setArSecondaryButtons] = useState([]);
-  const [actionButtons, setActionButtons] = useState<any>({});
-  const [stateChange, setStateChange] = useState(false);
+  const [actionButtons, setActionButtons] = useState<any>({});  
   const { t } = useTranslation();
-
-  PCore.getStore().subscribe(() => setStateChange(true));
+  
 
   const AssignmentCard = SdkComponentMap.getLocalComponentMap()['AssignmentCard'] ? SdkComponentMap.getLocalComponentMap()['AssignmentCard'] : SdkComponentMap.getPegaProvidedComponentMap()['AssignmentCard'];
 
@@ -47,11 +45,8 @@ export default function Assignment(props) {
   const cancelCreateStageAssignment = actionsAPI.cancelCreateStageAssignment.bind(actionsAPI);
   // const showPage = actionsAPI.showPage.bind(actionsAPI);
 
-  useEffect( () => {
-    stateChange && setStateChange(false);
-  }, [stateChange])
-
-  const isOnlyFieldDetails  = useIsOnlyField(null, [children, stateChange]);// .isOnlyField;
+  
+  const isOnlyFieldDetails  = useIsOnlyField(null, children);// .isOnlyField;
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
 

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -27,7 +27,10 @@ export default function Assignment(props) {
   const thePConn = getPConnect();
   const [arSecondaryButtons, setArSecondaryButtons] = useState([]);
   const [actionButtons, setActionButtons] = useState<any>({});
+  const [stateChange, setStateChange] = useState(false);
   const { t } = useTranslation();
+
+  PCore.getStore().subscribe(() => setStateChange(true));
 
   const AssignmentCard = SdkComponentMap.getLocalComponentMap()['AssignmentCard'] ? SdkComponentMap.getLocalComponentMap()['AssignmentCard'] : SdkComponentMap.getPegaProvidedComponentMap()['AssignmentCard'];
 
@@ -44,8 +47,11 @@ export default function Assignment(props) {
   const cancelCreateStageAssignment = actionsAPI.cancelCreateStageAssignment.bind(actionsAPI);
   // const showPage = actionsAPI.showPage.bind(actionsAPI);
 
+  useEffect( () => {
+    stateChange && setStateChange(false);
+  }, [stateChange])
 
-  const isOnlyFieldDetails  = useIsOnlyField(null, children);// .isOnlyField;
+  const isOnlyFieldDetails  = useIsOnlyField(null, [children, stateChange]);// .isOnlyField;
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
 


### PR DESCRIPTION
Adds a basic implementation of the Rich Text component to fulfil the requirements of US-9579, displaying of informational text with full markup

- Currently, the Rich Text components always displays the 'inputs' value run through a HTML parser as it is not expected that we will need a fully functional Rich Text editor within the application.

TO NOTE: The Parsed HTML component has added some config to configure DOMPurify to retain target attribute of '_blank' on <a> tags, and also adds noopener and noreferrer rel tags for basic security. This should mean that any a tags passed from pega config should now work correctly if configured to open in new tab. 