### PR TITLE
BUG-6776: Fixed error sequence issue on all screen except one

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -129,7 +129,6 @@ export default function Assignment(props) {
     return acc;
   }, [] );
 
-    errorStateProps.sort((a:OrderedErrorMessage, b:OrderedErrorMessage)=>{return a.displayOrder > b.displayOrder ? 1:-1})
     setErrorMessages([...errorStateProps]);
   }
 


### PR DESCRIPTION
Sorting logic is not working properly because displayOrder is not correct when form elements are not coming on same level from pega. By removing sorting logic, we are able to fixed issue on all screens except one which require pega change.