### PR TITLE
BUG-7384 - Re-ordered describeBy IDs to match visual order

### DIFF
--- a/src/components/BaseComponents/DateInput/DateInput.tsx
+++ b/src/components/BaseComponents/DateInput/DateInput.tsx
@@ -1,88 +1,135 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import FormGroup, {makeErrorId, makeHintId} from '../FormGroup/FormGroup';
-import FieldSet from '../FormGroup/FieldSet'
+import FormGroup, { makeErrorId, makeHintId } from '../FormGroup/FormGroup';
+import FieldSet from '../FormGroup/FieldSet';
 
-export default function DateInput(props){
-
-  const { name, errorText, hintText, value ,onChangeDay, onChangeMonth, onChangeYear, testId, inputProps={}, autoComplete} = props;
-  let {errorProps} = props;
+export default function DateInput(props) {
+  const {
+    name,
+    errorText,
+    hintText,
+    value,
+    onChangeDay,
+    onChangeMonth,
+    onChangeYear,
+    testId,
+    inputProps = {},
+    autoComplete
+  } = props;
+  let { errorProps } = props;
   const { t } = useTranslation();
 
-  if(!errorProps){
+  if (!errorProps) {
     errorProps = {};
-    if(!errorProps.specificError){
-      errorProps.specificError={day:true, month:true, year:true};
+    if (!errorProps.specificError) {
+      errorProps.specificError = { day: true, month: true, year: true };
     }
   }
 
-  const inputClasses = `govuk-input ${inputProps.className?inputProps.className:''
-}`.trim();
-  const widthClass= (width: number) => {
+  const inputClasses = `govuk-input ${inputProps.className ? inputProps.className : ''}`.trim();
+  const widthClass = (width: number) => {
     return `govuk-input--width-${width}`;
-  }
+  };
 
-  const errorClass= (targetOfError: boolean) => {
-    if(errorText){
-      return `${targetOfError?'govuk-input--error':null}`;
+  const errorClass = (targetOfError: boolean) => {
+    if (errorText) {
+      return `${targetOfError ? 'govuk-input--error' : null}`;
     }
-  }
+  };
 
   // NOTE - Calculating outside of JSX incase of future translation requirements
   const dayLabel = t('Day');
   const monthLabel = t('Month');
   const yearLabel = t('Year');
 
-  // TODO - Handle Autocomplete settings (if always required)
   // TODO - Investigate if possible to set error class per input depending on error message (e.g. if only year is missing, only error style year input)
 
-
-  const describedbyIds = `${errorText?makeErrorId(name):""} ${hintText?makeHintId(name):""}`.trim();
-  if(describedbyIds.length !== 0){
-    inputProps["aria-describedby"] = describedbyIds;
+  const describedbyIds = `${hintText ? makeHintId(name) : ''} ${
+    errorText ? makeErrorId(name) : ''
+  }`.trim();
+  if (describedbyIds.length !== 0) {
+    inputProps['aria-describedby'] = describedbyIds;
   }
 
-  let acDay = "";
-  let acMonth = "";
-  let acYear = "";
-  if(autoComplete === "bday"){
-    acDay = "bday-day";
-    acMonth = "bday-month";
-    acYear = "bday-year";
+  let acDay = '';
+  let acMonth = '';
+  let acYear = '';
+  if (autoComplete === 'bday') {
+    acDay = 'bday-day';
+    acMonth = 'bday-month';
+    acYear = 'bday-year';
   }
 
-  const extraProps= {testProps:{'data-test-id':testId}};
+  const extraProps = { testProps: { 'data-test-id': testId } };
 
-  return(
-    <FieldSet {...props} fieldsetElementProps={{role:"group"}} {...extraProps}>
-      <div className="govuk-date-input" id={name}>
-        <div className="govuk-date-input__item">
-          <FormGroup name={`${name}-day`} label={dayLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label">
-            <input className={[inputClasses, widthClass(2), errorClass(errorProps?.specificError?.day)].join(' ')}
-              id={`${name}-day`} name={`${name}-day`} type="text"
-              inputMode="numeric" value={value?.day}
+  return (
+    <FieldSet {...props} fieldsetElementProps={{ role: 'group' }} {...extraProps}>
+      <div className='govuk-date-input' id={name}>
+        <div className='govuk-date-input__item'>
+          <FormGroup
+            name={`${name}-day`}
+            label={dayLabel}
+            labelIsHeading={false}
+            extraLabelClasses='govuk-date-input__label'
+          >
+            <input
+              className={[
+                inputClasses,
+                widthClass(2),
+                errorClass(errorProps?.specificError?.day)
+              ].join(' ')}
+              id={`${name}-day`}
+              name={`${name}-day`}
+              type='text'
+              inputMode='numeric'
+              value={value?.day}
               onChange={onChangeDay}
               autoComplete={acDay || undefined}
             />
           </FormGroup>
         </div>
-        <div className="govuk-date-input__item">
-          <FormGroup name={`${name}-month`} label={monthLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label">
-            <input className={[inputClasses, widthClass(2), errorClass(errorProps?.specificError?.month)].join(' ')}
-              id={`${name}-month`} name={`${name}-month`} type="text"
-              inputMode="numeric" value={value?.month}
+        <div className='govuk-date-input__item'>
+          <FormGroup
+            name={`${name}-month`}
+            label={monthLabel}
+            labelIsHeading={false}
+            extraLabelClasses='govuk-date-input__label'
+          >
+            <input
+              className={[
+                inputClasses,
+                widthClass(2),
+                errorClass(errorProps?.specificError?.month)
+              ].join(' ')}
+              id={`${name}-month`}
+              name={`${name}-month`}
+              type='text'
+              inputMode='numeric'
+              value={value?.month}
               onChange={onChangeMonth}
               autoComplete={acMonth || undefined}
-             
             />
           </FormGroup>
         </div>
-        <div className="govuk-date-input__item">
-          <FormGroup name={`${name}-year`} label={yearLabel} labelIsHeading={false} extraLabelClasses="govuk-date-input__label">
-            <input className={[inputClasses, widthClass(4), errorClass(errorProps?.specificError?.year)].join(' ')}
-              id={`${name}-year`} name={`${name}-year`} type="text"
-              inputMode="numeric" value={value?.year}
+        <div className='govuk-date-input__item'>
+          <FormGroup
+            name={`${name}-year`}
+            label={yearLabel}
+            labelIsHeading={false}
+            extraLabelClasses='govuk-date-input__label'
+          >
+            <input
+              className={[
+                inputClasses,
+                widthClass(4),
+                errorClass(errorProps?.specificError?.year)
+              ].join(' ')}
+              id={`${name}-year`}
+              name={`${name}-year`}
+              type='text'
+              inputMode='numeric'
+              value={value?.year}
               onChange={onChangeYear}
               autoComplete={acYear || undefined}
             />
@@ -90,7 +137,7 @@ export default function DateInput(props){
         </div>
       </div>
     </FieldSet>
-    )
+  );
 }
 
 DateInput.propTypes = {
@@ -100,6 +147,16 @@ DateInput.propTypes = {
   onChangeDay: PropTypes.func,
   onChangeMonth: PropTypes.func,
   onChangeYear: PropTypes.func,
-  value: PropTypes.shape({day:PropTypes.string, month:PropTypes.string, year:PropTypes.string}),
-  errorProps: PropTypes.shape({specificError:PropTypes.shape({day:PropTypes.bool, month:PropTypes.bool, year:PropTypes.bool})}),
-}
+  value: PropTypes.shape({
+    day: PropTypes.string,
+    month: PropTypes.string,
+    year: PropTypes.string
+  }),
+  errorProps: PropTypes.shape({
+    specificError: PropTypes.shape({
+      day: PropTypes.bool,
+      month: PropTypes.bool,
+      year: PropTypes.bool
+    })
+  })
+};

--- a/src/components/BaseComponents/Select/Select.tsx
+++ b/src/components/BaseComponents/Select/Select.tsx
@@ -1,22 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {makeHintId, makeErrorId} from '../FormGroup/FormGroup';
+import { makeHintId, makeErrorId } from '../FormGroup/FormGroup';
 import FieldSet from '../FormGroup/FieldSet';
 
-export default function Select(props){
+export default function Select(props) {
+  const { name, onChange, value, children, errorText, hintText } = props;
 
-  const {name, onChange, value, children, errorText, hintText} = props;
+  const describedbyIds = `${hintText ? makeHintId(name) : ''} ${
+    errorText ? makeErrorId(name) : ''
+  }`.trim();
+  const ariaDescBy = describedbyIds.length !== 0 ? { 'aria-describedby': describedbyIds } : {};
 
-  const describedbyIds = `${errorText?makeErrorId(name):""} ${hintText?makeHintId(name):""}`.trim();
-  const ariaDescBy = describedbyIds.length !== 0 ? {'aria-describedby' : describedbyIds} : {};
-
-  return(
+  return (
     <FieldSet {...props}>
-        <select className="govuk-select" id={name} name={name} onChange={onChange} value={value} {...ariaDescBy}>
-          {children}
-        </select>
+      <select
+        className='govuk-select'
+        id={name}
+        name={name}
+        onChange={onChange}
+        value={value}
+        {...ariaDescBy}
+      >
+        {children}
+      </select>
     </FieldSet>
-  )
+  );
 }
 
 Select.propTypes = {
@@ -24,5 +32,5 @@ Select.propTypes = {
   name: PropTypes.string,
   children: PropTypes.node,
   onChange: PropTypes.func,
-  value: PropTypes.string,
-}
+  value: PropTypes.string
+};

--- a/src/components/BaseComponents/TextInput/TextInput.tsx
+++ b/src/components/BaseComponents/TextInput/TextInput.tsx
@@ -14,7 +14,8 @@ export default function TextInput(props) {
             <HintTextComponent htmlString={hintText} />
           </div>
         )}
-        <span className='govuk-body govuk-!-font-weight-bold read-only'>{inputProps.value}</span><br/>
+        <span className='govuk-body govuk-!-font-weight-bold read-only'>{inputProps.value}</span>
+        <br />
       </>
     );
   }
@@ -30,19 +31,18 @@ export default function TextInput(props) {
     } else return inputClasses;
   };
 
-  const keyHandler = (e)=> {
-    if(e.key === 'Enter'){   
-       e.preventDefault();
+  const keyHandler = e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
     }
   };
 
   // TODO - Handle input types (password, email, numeric) - Or investigate if these should be separate components, or can simple be handled by inputProps
-  // TODO - Handle autocomplete settings
 
-  const describedByIDs = `${errorText ? makeErrorId(name) : ''} ${
-    hintText ? makeHintId(name) : ''
+  const describedByIDs = `${hintText ? makeHintId(name) : ''} ${
+    errorText ? makeErrorId(name) : ''
   }`.trim();
-  if(describedByIDs.length !== 0){
+  if (describedByIDs.length !== 0) {
     inputProps['aria-describedby'] = describedByIDs;
   }
 


### PR DESCRIPTION
### Overview
Accessibility failure: [1.3.2 Meaningful Sequence](https://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence.html)

Text descriptions should match the visual order e.g., our component structure for a Text Input is..

Label
Hint
Error
Control

This error was raised as the error was being read _before_ the hint.  I switched this around in the necessary components to ensure the correct order

```
  const describedByIDs = `${hintText ? makeHintId(name) : ''} ${
    errorText ? makeErrorId(name) : ''
  }`.trim();
```

For radio buttons, checkbox groups etc we use a fieldset component which was already using the correct order so no changes there.

### Example fix
<img width="1617" alt="text-input-describedby-order-correct" src="https://github.com/norm-l/odx/assets/5471026/223d7df9-bc68-4399-8e2f-2bd9d22d1ccf">

### Additional changes
Lots of linting changes outside of this.