### PR TITLE
fix: BUG-7599 Shuttering service

### DIFF
--- a/src/components/helpers/hooks/useServiceShuttered.ts
+++ b/src/components/helpers/hooks/useServiceShuttered.ts
@@ -31,7 +31,6 @@ export default function ServiceShuttered() {
         console.error(err);
       });
   }
-  // }
 
   // Runs the is service shuttered function and sets the shutter rest api url when the view changes
   useEffect(() => {

--- a/src/components/helpers/hooks/useServiceShuttered.ts
+++ b/src/components/helpers/hooks/useServiceShuttered.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { getSdkConfig } from '@pega/react-sdk-components/lib/components/helpers/config_access';
+
+interface ResponseType {
+  data: { Shuttered: boolean };
+}
+
+export default function ServiceShuttered() {
+  const [serviceShuttered, setServiceShuttered] = useState(false);
+
+  function isServiceShuttered(shutterPageUrl: string) {
+    const featureID = 'ChB';
+    const featureType = 'Service';
+
+    const parameters = new URLSearchParams(
+      `{FeatureID: ${featureID}, FeatureType: ${featureType}}`
+    );
+
+    const url = `${shutterPageUrl}?dataViewParameters=${parameters}`;
+
+    const { invokeCustomRestApi } = PCore.getRestClient();
+    invokeCustomRestApi(url, {
+      method: 'GET'
+    })
+      .then((resp: ResponseType) => {
+        const isShuttered = resp.data.Shuttered;
+        setServiceShuttered(isShuttered);
+      })
+      .catch((err: Error) => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+  }
+  // }
+
+  // Runs the is service shuttered function and sets the shutter rest api url when the view changes
+  useEffect(() => {
+    getSdkConfig().then(sdkConfig => {
+      const url = new URL(
+        `${sdkConfig.serverConfig.infinityRestServerUrl}/app/${sdkConfig.serverConfig.appAlias}/api/application/v2/data_views/D_ShutterLookup`
+      );
+      isServiceShuttered(url.href);
+    });
+  }, []);
+
+  return { serviceShuttered };
+}

--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -3,85 +3,138 @@ import { useTranslation } from 'react-i18next';
 import ParsedHTML from '../../components/helpers/formatters/ParsedHtml';
 import MainWrapper from '../../components/BaseComponents/MainWrapper';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
+import useServiceShuttered from '../../components/helpers/hooks/useServiceShuttered';
+import ShutterServicePage from '../../components/AppComponents/ShutterServicePage';
 
-declare const PCore : any;
+declare const PCore: any;
 
-const ConfirmationPage = ({caseId}) => {
-
+const ConfirmationPage = ({ caseId }) => {
   const { t } = useTranslation();
   const [documentList, setDocumentList] = useState(``);
   const [isBornAbroadOrAdopted, setIsBornAbroadOrAdopted] = useState(false);
   const [returnSlipContent, setReturnSlipContent] = useState();
   const [loading, setLoading] = useState(true);
-  
+  const { serviceShuttered } = useServiceShuttered();
+
   const docIDForDocList = 'CR0003';
   const docIDForReturnSlip = 'CR0002';
-  const locale = PCore.getEnvironmentInfo().locale.replaceAll('-','_');
+  const locale = PCore.getEnvironmentInfo().locale.replaceAll('-', '_');
 
-  useEffect(()=> {
+  useEffect(() => {
     setPageTitle();
   }, []);
 
-  useEffect(()=>{
-    PCore.getDataPageUtils().getPageDataAsync('D_DocumentContent', 'root', {DocumentID: docIDForDocList, Locale: locale, CaseID: caseId}).then(listData => {
-      if(listData.DocumentContentHTML.includes("data-bornabroad='true'") || listData.DocumentContentHTML.includes("data-adopted='true'")){
-        setIsBornAbroadOrAdopted(true);
-      }
-      setLoading(false);
-      setDocumentList(listData.DocumentContentHTML);
-    }).catch(err => {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    });
+  useEffect(() => {
+    PCore.getDataPageUtils()
+      .getPageDataAsync('D_DocumentContent', 'root', {
+        DocumentID: docIDForDocList,
+        Locale: locale,
+        CaseID: caseId
+      })
+      .then(listData => {
+        if (
+          listData.DocumentContentHTML.includes("data-bornabroad='true'") ||
+          listData.DocumentContentHTML.includes("data-adopted='true'")
+        ) {
+          setIsBornAbroadOrAdopted(true);
+        }
+        setLoading(false);
+        setDocumentList(listData.DocumentContentHTML);
+      })
+      .catch(err => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
 
-    PCore.getDataPageUtils().getPageDataAsync('D_DocumentContent', 'root', {DocumentID: docIDForReturnSlip, Locale: locale, CaseID: caseId}).then(pageData => {
-      setReturnSlipContent(pageData.DocumentContentHTML);
-    }).catch(err => {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    });
-  },[])
+    PCore.getDataPageUtils()
+      .getPageDataAsync('D_DocumentContent', 'root', {
+        DocumentID: docIDForReturnSlip,
+        Locale: locale,
+        CaseID: caseId
+      })
+      .then(pageData => {
+        setReturnSlipContent(pageData.DocumentContentHTML);
+      })
+      .catch(err => {
+        // eslint-disable-next-line no-console
+        console.error(err);
+      });
+  }, []);
 
-  const generateReturnSlip = (e) => {
+  const generateReturnSlip = e => {
     e.preventDefault();
-    const myWindow = window.open("");
+    const myWindow = window.open('');
     myWindow.document.write(returnSlipContent);
-  }
+  };
 
-  if(loading){
+  if (loading) {
     return null;
-  } else if(!loading && isBornAbroadOrAdopted) {
+  } else if (serviceShuttered) {
+    return <ShutterServicePage />;
+  } else if (!loading && isBornAbroadOrAdopted) {
     return (
       <MainWrapper>
         <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
-          <h1 className='govuk-panel__title'> {t("APPLICATION_RECEIVED")}</h1>
-          <div className='govuk-panel__body govuk-!-font-size-27'>{t('POST_YOUR_SUPPORTING_DOCUMENTS')}</div>
+          <h1 className='govuk-panel__title'> {t('APPLICATION_RECEIVED')}</h1>
+          <div className='govuk-panel__body govuk-!-font-size-27'>
+            {t('POST_YOUR_SUPPORTING_DOCUMENTS')}
+          </div>
         </div>
         <h2 className='govuk-heading-m'> {t('WHAT_YOU_NEED_TO_DO_NOW')} </h2>
         <p className='govuk-body'> {t('THE_INFO_YOU_HAVE_PROVIDED')} </p>
-        <ParsedHTML htmlString={documentList}/>
+        <ParsedHTML htmlString={documentList} />
         <p className='govuk-body'> {t('HMRC_MIGHT_CALL_YOU')} </p>
-        <p className='govuk-body'> {t('AFTER_YOU_HAVE')} <a href='' onClick={(e)=>generateReturnSlip(e)}>{t('PRINTED_AND_SIGNED_THE_FORM')} {t('OPENS_IN_NEW_TAB')}</a>, {t('RETURN_THE_FORM_WITH')} </p>
+        <p className='govuk-body'>
+          {' '}
+          {t('AFTER_YOU_HAVE')}{' '}
+          <a href='' onClick={e => generateReturnSlip(e)}>
+            {t('PRINTED_AND_SIGNED_THE_FORM')} {t('OPENS_IN_NEW_TAB')}
+          </a>
+          , {t('RETURN_THE_FORM_WITH')}{' '}
+        </p>
         <p className='govuk-body govuk-!-font-weight-bold'>
-          Child Benefit Office (GB)<br/>
-          Washington<br/>
-          NEWCASTLE UPON TYNE<br/>
+          Child Benefit Office (GB)
+          <br />
+          Washington
+          <br />
+          NEWCASTLE UPON TYNE
+          <br />
           NE88 1ZD
         </p>
         <p className='govuk-body'> {t('WE_NORMALLY_RETURN_DOCUMENTS_WITHIN')} </p>
-        <p className='govuk-body'><a href='https://www.tax.service.gov.uk/feedback/ODXCHB' className="govuk-link" target="_blank" rel="noreferrer">{t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} </a>{t('TAKES_30_SECONDS')}</p>
+        <p className='govuk-body'>
+          <a
+            href='https://www.tax.service.gov.uk/feedback/ODXCHB'
+            className='govuk-link'
+            target='_blank'
+            rel='noreferrer'
+          >
+            {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')}{' '}
+          </a>
+          {t('TAKES_30_SECONDS')}
+        </p>
       </MainWrapper>
     );
   } else {
     return (
       <MainWrapper>
         <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
-          <h1 className='govuk-panel__title'> {t("APPLICATION_RECEIVED")}</h1>
+          <h1 className='govuk-panel__title'> {t('APPLICATION_RECEIVED')}</h1>
         </div>
-        <h2 className='govuk-heading-m'> {t("WHAT_HAPPENS_NEXT")}</h2>
-        <p className='govuk-body'> {t("WE_HAVE_SENT_YOUR_APPLICATION")}</p>
-        <p className='govuk-body'> {t("WE_WILL_TELL_YOU_IN_14_DAYS")}</p>
-        <p className='govuk-body'><a href='https://www.tax.service.gov.uk/feedback/ODXCHB' className="govuk-link" target="_blank" rel="noreferrer">{t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} </a>{t('TAKES_30_SECONDS')}</p>
+        <h2 className='govuk-heading-m'> {t('WHAT_HAPPENS_NEXT')}</h2>
+        <p className='govuk-body'> {t('WE_HAVE_SENT_YOUR_APPLICATION')}</p>
+        <p className='govuk-body'> {t('WE_WILL_TELL_YOU_IN_14_DAYS')}</p>
+        <p className='govuk-body'>
+          <a
+            href='https://www.tax.service.gov.uk/feedback/ODXCHB'
+            className='govuk-link'
+            target='_blank'
+            rel='noreferrer'
+          >
+            {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')}{' '}
+          </a>
+          {t('TAKES_30_SECONDS')}
+        </p>
       </MainWrapper>
     );
   }

--- a/src/samples/ChildBenefitsClaim/StartPage.tsx
+++ b/src/samples/ChildBenefitsClaim/StartPage.tsx
@@ -3,82 +3,90 @@ import Button from '../../components/BaseComponents/Button/Button';
 import { useTranslation } from 'react-i18next';
 import MainWrapper from '../../components/BaseComponents/MainWrapper';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
-
+import useServiceShuttered from '../../components/helpers/hooks/useServiceShuttered';
+import ShutterServicePage from '../../components/AppComponents/ShutterServicePage';
 
 const StartPage: React.FC<{ onStart: React.MouseEventHandler; onBack: any }> = ({
   onStart,
   onBack
 }) => {
   const { t } = useTranslation();
+  const { serviceShuttered } = useServiceShuttered();
 
-  useEffect(()=>{
+  useEffect(() => {
     setPageTitle();
-  },[])
+  }, []);
 
   return (
     <>
-      <Button
-        variant='backlink'
-        onClick={onBack}
-        key='StartPageBacklink'
-        attributes={{ type: 'link' }}
-      />
-      <MainWrapper>
-        <h1 className='govuk-heading-xl'>{t('BEGIN_NEW_CHB_CLAIM')}</h1>
-        <p className='govuk-body'>
-          {t('USE_THIS_FORM_TO_CLAIM')}
-          <a
-            className='govuk-link '
-            target='_blank'
-            rel='noopener noreferrer'
-            href='https://www.gov.uk/child-benefit-16-19'
-          >
-            {t('USE_THIS_FORM_TO_CLAIM_CONTD')} {t('OPENS_IN_NEW_TAB')}
-          </a>
-          .
-        </p>
-        <h2 className='govuk-heading-m'>{t('WHO_CAN_APPLY')}</h2>
-        <p className='govuk-body'>{t('ONLY_ONE_PERSON_CAN')}</p>
-        <p className='govuk-body'>{t('IF_YOU_ARE_IN_COUPLE')}</p>
-        <p className='govuk-body'>{t('YOU_DONT_NEED_TO_BE_PARENT')}</p>
-        <h2 className='govuk-heading-m'>{t('WHEN_TO_APPLY')}</h2>
-        <p className='govuk-body'>{t('CLAIM_AS_SOON_AS_BABY_IS_BORN')}</p>
-        <p className='govuk-body'>{t('CHILD_MUST_BE_UNDER_16')}</p>
-        <h2 className='govuk-heading-m'> {t('BEFORE_YOU_START')}</h2>
-        <p className='govuk-body'>{t('TO_COMPLETE_THIS_FORM_YOU_NEED')}</p>
-        <ul className='govuk-list govuk-list--bullet'>
-          <li> {t('BIRTH_CERTIFICATE')}</li>
-          <li>{t('PASSPORT_OR_TRAVEL_DOCUMENT')}</li>
-          <li>{t('ADOPTION_CERTIFICATE')}</li>
-        </ul>
-        <p className='govuk-body'>{t('YOU_WILL_ALSO_NEED')}</p>
-        <ul className='govuk-list govuk-list--bullet'>
-          <li>{t('YOUR_BANK_OR_BUILDING_DETAILS')}</li>
-          <li>{t('YOUR_NINUMBER')}</li>
-          <li>{t('PARTNERS_NINUMBER')}</li>
-        </ul>
-        <div className='govuk-warning-text'>
-          <span className='govuk-warning-text__icon' aria-hidden='true'>
-            !
-          </span>
-          <strong className='govuk-warning-text__text'>
-            <span className='govuk-warning-text__assistive'>{t('WARNING')}</span>
-            {t('DO_NOT_DELAY_MAKING')}
-          </strong>
-        </div>
-        <Button variant='start' onClick={onStart}>
-          {t('START_NOW')}
-        </Button>
-        <p className='govuk-body'>
-          {t('IF_YOU_HAVE_ANY_QUESTIONS_REG_CHB')}
-          <a
-            href='https://www.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit'
-            className='govuk-link'
-          >
-            {t('CONTACT_THE_CHILD_BENEFIT_HELPLINE')}
-          </a>
-        </p>
-      </MainWrapper>
+      {' '}
+      {!serviceShuttered && (
+        <>
+          <Button
+            variant='backlink'
+            onClick={onBack}
+            key='StartPageBacklink'
+            attributes={{ type: 'link' }}
+          />
+          <MainWrapper>
+            <h1 className='govuk-heading-xl'>{t('BEGIN_NEW_CHB_CLAIM')}</h1>
+            <p className='govuk-body'>
+              {t('USE_THIS_FORM_TO_CLAIM')}
+              <a
+                className='govuk-link '
+                target='_blank'
+                rel='noopener noreferrer'
+                href='https://www.gov.uk/child-benefit-16-19'
+              >
+                {t('USE_THIS_FORM_TO_CLAIM_CONTD')} {t('OPENS_IN_NEW_TAB')}
+              </a>
+              .
+            </p>
+            <h2 className='govuk-heading-m'>{t('WHO_CAN_APPLY')}</h2>
+            <p className='govuk-body'>{t('ONLY_ONE_PERSON_CAN')}</p>
+            <p className='govuk-body'>{t('IF_YOU_ARE_IN_COUPLE')}</p>
+            <p className='govuk-body'>{t('YOU_DONT_NEED_TO_BE_PARENT')}</p>
+            <h2 className='govuk-heading-m'>{t('WHEN_TO_APPLY')}</h2>
+            <p className='govuk-body'>{t('CLAIM_AS_SOON_AS_BABY_IS_BORN')}</p>
+            <p className='govuk-body'>{t('CHILD_MUST_BE_UNDER_16')}</p>
+            <h2 className='govuk-heading-m'> {t('BEFORE_YOU_START')}</h2>
+            <p className='govuk-body'>{t('TO_COMPLETE_THIS_FORM_YOU_NEED')}</p>
+            <ul className='govuk-list govuk-list--bullet'>
+              <li> {t('BIRTH_CERTIFICATE')}</li>
+              <li>{t('PASSPORT_OR_TRAVEL_DOCUMENT')}</li>
+              <li>{t('ADOPTION_CERTIFICATE')}</li>
+            </ul>
+            <p className='govuk-body'>{t('YOU_WILL_ALSO_NEED')}</p>
+            <ul className='govuk-list govuk-list--bullet'>
+              <li>{t('YOUR_BANK_OR_BUILDING_DETAILS')}</li>
+              <li>{t('YOUR_NINUMBER')}</li>
+              <li>{t('PARTNERS_NINUMBER')}</li>
+            </ul>
+            <div className='govuk-warning-text'>
+              <span className='govuk-warning-text__icon' aria-hidden='true'>
+                !
+              </span>
+              <strong className='govuk-warning-text__text'>
+                <span className='govuk-warning-text__assistive'>{t('WARNING')}</span>
+                {t('DO_NOT_DELAY_MAKING')}
+              </strong>
+            </div>
+            <Button variant='start' onClick={onStart}>
+              {t('START_NOW')}
+            </Button>
+            <p className='govuk-body'>
+              {t('IF_YOU_HAVE_ANY_QUESTIONS_REG_CHB')}
+              <a
+                href='https://www.gov.uk/government/organisations/hm-revenue-customs/contact/child-benefit'
+                className='govuk-link'
+              >
+                {t('CONTACT_THE_CHILD_BENEFIT_HELPLINE')}
+              </a>
+            </p>
+          </MainWrapper>
+        </>
+      )}
+      {serviceShuttered && <ShutterServicePage />}
     </>
   );
 };


### PR DESCRIPTION
Problem -

Shuttering the Child beneft service is ON Claimant is still able to click
"Begin new claim", "start now" 
"Accept and send"
"Continue claim"

Solution - 
Prepared a common hook to show service unavailable page if Shuttering is ON

Changes- 
Assignment.tsx - Code optimisation - Call to shutter hook added & previous implementation has been removed 
ConfirmationPage.tsx - Implementation was missing on this page, added 1line call to hook and updated render part
StartPage.tsx- Implementation was missing on this page, added 1line call to hook and updated render part