### PR TITLE
US-9579 - fix warning text display

### DIFF
--- a/src/components/custom-sdk/field/HMRC_ODX_ComplexQuestionExplanation/index.tsx
+++ b/src/components/custom-sdk/field/HMRC_ODX_ComplexQuestionExplanation/index.tsx
@@ -52,12 +52,12 @@ export default function HmrcOdxComplexQuestionExplanation(props: HmrcOdxComplexQ
 
   const replaceWarningTextBlockHook = (node) => {      
     if(node.childNodes){
-      deepNodeList(node.childNodes, (node) => {
-        if (node.parentNode.innerText && node.parentNode.innerText?.indexOf( `${warning}!!!`) !== -1) 
+      deepNodeList(node.childNodes, (deepNode) => {
+        if (deepNode.parentNode.innerText && deepNode.parentNode.innerText?.indexOf( `${warning}!!!`) !== -1) 
         {
-          const originalInnerHTML = node.parentNode.innerHTML;
+          const originalInnerHTML = deepNode.parentNode.innerHTML;
           const trimmedInnerHTML = originalInnerHTML.replace(`${warning}!!!`, '');
-          node.parentNode.innerHTML = `<div class="govuk-warning-text">
+          deepNode.parentNode.innerHTML = `<div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
               <strong class="govuk-warning-text__text">
                 <span class="govuk-warning-text__assistive">${warning}</span>

--- a/src/components/custom-sdk/field/HMRC_ODX_ComplexQuestionExplanation/index.tsx
+++ b/src/components/custom-sdk/field/HMRC_ODX_ComplexQuestionExplanation/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ParsedHTML from '../../../helpers/formatters/ParsedHtml';
+import { useTranslation } from 'react-i18next';
 import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
 import type { PConnFieldProps } from '@pega/react-sdk-components/lib/types/PConnProps';
 
@@ -14,9 +15,17 @@ interface HmrcOdxComplexQuestionExplanationProps extends PConnFieldProps {
 export default function HmrcOdxComplexQuestionExplanation(props: HmrcOdxComplexQuestionExplanationProps) {
   const {
     value = '',
+    readOnly
   } = props;  
   
+  const { t } = useTranslation();
   registerNonEditableField();  
+
+  if(readOnly){
+    return null;
+  }
+  
+  const warning = t('WARNING');
 
   const addGovukBodyToParagraphHook = (node) => {
     const govukBodyClass = 'govuk-body';
@@ -29,8 +38,39 @@ export default function HmrcOdxComplexQuestionExplanation(props: HmrcOdxComplexQ
     }
   }  
 
+  const deepNodeList = (nodeList, callBack) => {
+    nodeList.forEach( node => {
+      if(node.childNodes && node.childNodes.length > 0){
+        deepNodeList(node.childNodes, callBack)
+      }
+      else {
+        callBack(node)
+      }
+    })
+
+  }
+
+  const replaceWarningTextBlockHook = (node) => {      
+    if(node.childNodes){
+      deepNodeList(node.childNodes, (node) => {
+        if (node.parentNode.innerText && node.parentNode.innerText?.indexOf( `${warning}!!!`) !== -1) 
+        {
+          const originalInnerHTML = node.parentNode.innerHTML;
+          const trimmedInnerHTML = originalInnerHTML.replace(`${warning}!!!`, '');
+          node.parentNode.innerHTML = `<div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">${warning}</span>
+                ${trimmedInnerHTML}
+              </strong>
+            </div>`;
+        }
+      })    
+    }
+  }  
+    
   return (
-    <ParsedHTML htmlString={value} DOMSanitiseHooks={[addGovukBodyToParagraphHook]}/>        
+    <ParsedHTML htmlString={value} DOMSanitiseHooks={[addGovukBodyToParagraphHook, replaceWarningTextBlockHook]}/>        
   );
 }
 


### PR DESCRIPTION
Adds handling for warning text display in ComplexQuestionExplanaiton and hides when readonly

Adds a variant of the handling for Warning Text display to the ComplexQuestionExplanation component, which does not rely on the <strong> tag

Also added fix to hide explanation text in the summary page.

