### PR TITLE
A fix for bug 7310 to get correct welsh content

### DIFF
--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -534,7 +534,7 @@ export default function ChildBenefitsClaim() {
         handleSignout={handleSignout}
         appname={t('CLAIM_CHILD_BENEFIT')}
         hasLanguageToggle
-        isPegaApp={bShowPega}
+        isPegaApp={true}
       />
       <div className='govuk-width-container'>
         {shutterServicePage ? (


### PR DESCRIPTION
As a part of this we are reverting pega_app flag as true which was modified as a part of bug 7310.

Now that we are able to call generics api on each page load or new page fetch , so that we can update content with correct language.