### PR TITLE
feat: US10790 - Check your answers - Provision to appear comma separated value

### DIFF
--- a/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
+++ b/src/components/BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay.tsx
@@ -1,28 +1,39 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-export default function ReadOnlyDisplay(props){
+export default function ReadOnlyDisplay(props) {
+  const COMMA_DELIMITED_FIELD = 'CSV';
+  const { label, value, name } = props;
+  const [formattedValue, setFormattedValue] = useState<string | []>(value);
 
-  const {label, value} = props;
+  useEffect(() => {
+    if (name && name.indexOf(COMMA_DELIMITED_FIELD) !== -1 && value.indexOf(',') !== -1) {
+      const formatValue = value.split(',').map((item: string) => item.trim());
+      setFormattedValue(formatValue);
+    }
+  }, []);
 
   return (
-    <div className="govuk-summary-list__row">
-      <dt className="govuk-summary-list__key">{label}</dt>
+    <div className='govuk-summary-list__row'>
+      <dt className='govuk-summary-list__key'>{label}</dt>
 
-      <dd className="govuk-summary-list__value">
-      { Array.isArray(value) ?
-        <ul className="govuk-list">
-          {value.map( valueItem => <li key={valueItem}>{valueItem}</li>)}
-        </ul>
-        :
-        value
-      } </dd>
+      <dd className='govuk-summary-list__value'>
+        {Array.isArray(formattedValue) ? (
+          <ul className='govuk-list'>
+            {formattedValue.map(valueItem => (
+              <li key={valueItem}>{valueItem}</li>
+            ))}
+          </ul>
+        ) : (
+          formattedValue
+        )}{' '}
+      </dd>
     </div>
-  )
+  );
 }
-
 
 ReadOnlyDisplay.propTypes = {
   label: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-}
+  name: PropTypes.string
+};

--- a/src/components/override-sdk/field/TextInput/TextInput.tsx
+++ b/src/components/override-sdk/field/TextInput/TextInput.tsx
@@ -50,7 +50,7 @@ export default function TextInput(props) {
   const maxLength = fieldMetadata?.maxLength;
 
   if (readOnly) {
-    return <ReadOnlyDisplay label={label} value={value} />;
+    return <ReadOnlyDisplay label={label} value={value} name={name}/>;
   }
 
   const extraProps = { testProps: { 'data-test-id': testId } };


### PR DESCRIPTION
Common logic to separate out Comma(,) concatenated fields to make them appear on next line for 'CSV' field.

Refer screenshot below -
![image](https://github.com/norm-l/odx/assets/154439730/653e91b7-589b-4c89-8259-39b58cd10bb1)
