### PR TITLE
US-12284 : Remove save and come back link , rename cancel button in Un-Auth journey

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -51,6 +51,7 @@
   "APPLICATION_FOR_CHB_COMPLETE": "Application for Child Benefit complete",
 
   "APPLICATION_RECEIVED": "Application for Child Benefit received",
+  "CLOSE_CLAIM": "Close claim",
   "YOUR_REF_NUMBER": "Your reference number",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Post your supporting documents",
   "WHAT_YOU_NEED_TO_DO_NOW": "What you need to do now",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -51,6 +51,7 @@
   "APPLICATION_FOR_CHB_COMPLETE": "Application for Child Benefit complete",
 
   "APPLICATION_RECEIVED": "Application for Child Benefit received",
+  "CLOSE_CLAIM": "Close claim",
   "YOUR_REF_NUMBER": "Your reference number",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Post your supporting documents",
   "WHAT_YOU_NEED_TO_DO_NOW": "What you need to do now",

--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -70,3 +70,13 @@ export const isFieldSetReqiredForSelectComponent = (label: string) => {
   const arrFieldSetNotRequiredForSelectComponent = ['name of building society'];
   return !arrFieldSetNotRequiredForSelectComponent.includes(label.toLocaleLowerCase());
 };
+
+export const isUnAuthJourney = () => {
+  const containername = PCore.getContainerUtils().getActiveContainerItemName(
+    `${PCore.getConstants().APP.APP}/primary`
+  );
+  const context = PCore.getContainerUtils().getActiveContainerItemName(`${containername}/workarea`);
+  const UnAuth = PCore.getStoreValue('.CaseType', 'caseInfo.content', context);
+  const isUnAuthJourney = UnAuth === 'Unauth' ? true : false;
+  return isUnAuthJourney;
+};

--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -76,7 +76,6 @@ export const isUnAuthJourney = () => {
     `${PCore.getConstants().APP.APP}/primary`
   );
   const context = PCore.getContainerUtils().getActiveContainerItemName(`${containername}/workarea`);
-  const UnAuth = PCore.getStoreValue('.CaseType', 'caseInfo.content', context);
-  const isUnAuthJourney = UnAuth === 'Unauth' ? true : false;
-  return isUnAuthJourney;
+  const caseType = PCore.getStoreValue('.CaseType', 'caseInfo.content', context);
+  return caseType === 'Unauth';
 };

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -43,7 +43,7 @@ export default function ActionButtons(props) {
               key={sButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {!isUnAuth ? localizedVal(sButton.name, localeCategory) : t('CLOSE_CLAIM')}
+              {isUnAuth ? t('CLOSE_CLAIM') : localizedVal(sButton.name, localeCategory)}
             </Button>
           ) : null
         )}

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '../../../BaseComponents/Button/Button';
+import { useTranslation } from 'react-i18next';
 
 export default function ActionButtons(props) {
-  const { arMainButtons, arSecondaryButtons, onButtonPress } = props;
+  const { arMainButtons, arSecondaryButtons, onButtonPress, isUnAuth } = props;
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const localeCategory = 'Assignment';
+  const { t } = useTranslation();
   function _onButtonPress(sAction: string, sButtonType: string) {
     onButtonPress(sAction, sButtonType);
   }
@@ -14,7 +16,7 @@ export default function ActionButtons(props) {
     <>
       <div className='govuk-button-group govuk-!-padding-top-4'>
         {arMainButtons.map(mButton =>
-           mButton.name !== 'Hidden' ? (
+          mButton.name !== 'Hidden' ? (
             <Button
               variant='primary'
               onClick={e => {
@@ -41,29 +43,30 @@ export default function ActionButtons(props) {
               key={sButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {localizedVal(sButton.name, localeCategory)}
+              {!isUnAuth ? localizedVal(sButton.name, localeCategory) : t('CLOSE_CLAIM')}
             </Button>
           ) : null
         )}
       </div>
 
-        {arSecondaryButtons.map(sButton =>
+      {!isUnAuth &&
+        arSecondaryButtons.map(sButton =>
           sButton.actionID !== 'back' &&
           sButton.name !== 'Hidden' &&
           sButton.name.indexOf('Save') !== -1 ? (
             <Button
-            variant='link'
+              variant='link'
               onClick={e => {
                 e.target.blur();
                 _onButtonPress(sButton.jsAction, 'secondary');
               }}
               key={sButton.actionID}
               attributes={{ type: 'link' }}
-            >{localizedVal(sButton.name, localeCategory)}</Button>
+            >
+              {localizedVal(sButton.name, localeCategory)}
+            </Button>
           ) : null
         )}
-
-
     </>
   );
 }
@@ -72,6 +75,7 @@ ActionButtons.propTypes = {
   arMainButtons: PropTypes.array,
   arSecondaryButtons: PropTypes.array,
   onButtonPress: PropTypes.func,
+  isUnAuth: PropTypes.bool
   // buildName: PropTypes.string
 };
 

--- a/src/components/override-sdk/infra/AssignmentCard/AssignmentCard.tsx
+++ b/src/components/override-sdk/infra/AssignmentCard/AssignmentCard.tsx
@@ -5,7 +5,7 @@ import { isUnAuthJourney } from '../../../helpers/utils';
 import ActionButtons from '../ActionButtons';
 
 export default function AssignmentCard(props) {
-  const { children, actionButtons, onButtonPress, getPConnect } = props;
+  const { children, actionButtons, onButtonPress } = props;
 
   const [arMainButtons, setArMainButtons] = useState([]);
   const [arSecondaryButtons, setArSecondaryButtons] = useState([]);

--- a/src/components/override-sdk/infra/AssignmentCard/AssignmentCard.tsx
+++ b/src/components/override-sdk/infra/AssignmentCard/AssignmentCard.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { isUnAuthJourney } from '../../../helpers/utils';
 
-import ActionButtons from "../ActionButtons";
+import ActionButtons from '../ActionButtons';
 
 export default function AssignmentCard(props) {
-  const { children, actionButtons, onButtonPress} = props;
+  const { children, actionButtons, onButtonPress, getPConnect } = props;
 
   const [arMainButtons, setArMainButtons] = useState([]);
   const [arSecondaryButtons, setArSecondaryButtons] = useState([]);
 
-  useEffect( ()=> {
+  useEffect(() => {
     if (actionButtons) {
       setArMainButtons(actionButtons.main);
       setArSecondaryButtons(actionButtons.secondary);
@@ -23,11 +24,16 @@ export default function AssignmentCard(props) {
   return (
     <>
       {children}
-      {
-        arMainButtons && arSecondaryButtons && <ActionButtons arMainButtons={arMainButtons} arSecondaryButtons={arSecondaryButtons} onButtonPress={buttonPress}></ActionButtons>
-      }
+      {arMainButtons && arSecondaryButtons && (
+        <ActionButtons
+          arMainButtons={arMainButtons}
+          arSecondaryButtons={arSecondaryButtons}
+          onButtonPress={buttonPress}
+          isUnAuth={isUnAuthJourney()}
+        ></ActionButtons>
+      )}
     </>
-  )
+  );
 }
 
 AssignmentCard.propTypes = {
@@ -40,6 +46,6 @@ AssignmentCard.propTypes = {
 };
 
 AssignmentCard.defaultProps = {
-  itemKey: null,
+  itemKey: null
   // buildName: null
 };


### PR DESCRIPTION
As a part of this User story  , Save and come back link is been removed.

cancel button is renamed to close claim.

created a common functionality and placed it in utils , so if any un-auth related story comes in near future, we can use that functionality for conditioning.