### PR TITLE
US-12336 : Replace text takes 30 seconds to opens in new tab

### DIFF
--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -128,7 +128,7 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
             <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
               {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')}{' '}
             </a>
-            {t('TAKES_30_SECONDS')}
+            {t('OPENS_IN_NEW_TAB')}
           </p>
         </MainWrapper>
       </>
@@ -154,7 +154,7 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
             <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
               {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')}{' '}
             </a>
-            {t('TAKES_30_SECONDS')}
+            {t('OPENS_IN_NEW_TAB')}
           </p>
         </MainWrapper>
       </>


### PR DESCRIPTION
As per the comment given by Alex on US-12336 , we need to replace the text "takes 30 seconds" to "opens in new tab"
at the confirmation screen.

![image](https://github.com/norm-l/odx/assets/149078642/3933c30e-ed26-4787-93c1-d83ce11fc99c)
