### PR TITLE
Bug-7776 Re-order date errors if user tries to use a combination of text and numeric values. 

### DIFF
--- a/src/components/BaseComponents/ErrorSummary/ErrorSummary.tsx
+++ b/src/components/BaseComponents/ErrorSummary/ErrorSummary.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { checkErrorDateFormat } from '../../helpers/utils';
 
 export default function ErrorSummary(props) {
   const { errors } = props;
@@ -8,31 +9,42 @@ export default function ErrorSummary(props) {
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const localeCategory = 'Messages';
 
-  useEffect( () => {
-    if(errorSummaryRef && errorSummaryRef?.current){
-      errorSummaryRef.current.focus()
-    }}, [errorSummaryRef])
+  useEffect(() => {
+    if (errorSummaryRef && errorSummaryRef?.current) {
+      errorSummaryRef.current.focus();
+    }
+  }, [errorSummaryRef]);
 
   function onClick(e) {
-    const ref = e.target.href.indexOf("#") && e.target.href.split("#").pop();
-    const target:any = document.getElementById(ref);
+    const ref = e.target.href.indexOf('#') && e.target.href.split('#').pop();
+    const target: any = document.getElementById(ref);
     if (!target) return !1;
     target.focus();
     e.preventDefault();
-  };
-
+  }
 
   return (
-    <div ref={errorSummaryRef} className='govuk-error-summary' data-module='govuk-error-summary' tabIndex={-1} >
+    <div
+      ref={errorSummaryRef}
+      className='govuk-error-summary'
+      data-module='govuk-error-summary'
+      tabIndex={-1}
+    >
       <div role='alert'>
         <h2 className='govuk-error-summary__title'>There is a problem</h2>
         <div className='govuk-error-summary__body'>
           <ul className='govuk-list govuk-error-summary__list'>
-              {errors.map(error => {
-                return <li key={error.fieldId}>
-                  <a href={`#${error.fieldId}`} onClick={onClick}>{localizedVal(error.message, localeCategory /* ,localeReference */)}</a>
+            {errors.map(error => {
+              return (
+                <li key={error.fieldId}>
+                  <a href={`#${error.fieldId}`} onClick={onClick}>
+                    {checkErrorDateFormat(
+                      localizedVal(error.message, localeCategory /* ,localeReference */)
+                    )}
+                  </a>
                 </li>
-              })}
+              );
+            })}
           </ul>
         </div>
       </div>
@@ -41,5 +53,7 @@ export default function ErrorSummary(props) {
 }
 
 ErrorSummary.propTypes = {
-  errors: PropTypes.arrayOf(PropTypes.shape({fieldId: PropTypes.string, message: PropTypes.string})),
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({ fieldId: PropTypes.string, message: PropTypes.string })
+  )
 };

--- a/src/components/BaseComponents/FormGroup/FieldSet.tsx
+++ b/src/components/BaseComponents/FormGroup/FieldSet.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ConditionalWrapper from '../../helpers/formatters/ConditionalWrapper';
 import HintTextComponent from '../../helpers/formatters/ParsedHtml';
 import { DefaultFormContext, ErrorMsgContext } from '../../helpers/HMRCAppContext';
-import { checkErrorMsgs } from '../../helpers/utils';
+import { checkErrorMsgs, checkErrorDateFormat } from '../../helpers/utils';
 import InstructionTextComponent from '../../override-sdk/template/DefaultForm/InstructionTextComponent';
 
 export default function FieldSet({
@@ -24,7 +24,8 @@ export default function FieldSet({
   useEffect(() => {
     const found = checkErrorMsgs(errorMsgs, name);
     if (!found) {
-      setErrorMessage(errorText);
+      const errText = checkErrorDateFormat(errorText);
+      setErrorMessage(errText);
     }
   }, [errorText, errorMsgs]);
   const formGroupDivClasses = `govuk-form-group ${

--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -11,6 +11,30 @@ export const GBdate = date => {
   return d.length > 1 ? `${d[2]}/${d[1]}/${d[0]}` : date;
 };
 
+export const checkErrorDateFormat = errMessage => {
+  const regex = /([A-Za-z0-9]+(-[A-Za-z0-9]+)+)/;
+
+  // Check if the string has a date matching the regex format
+  if (regex.test(errMessage)) {
+    // Return just the date from the string
+    const dateMatch = regex.exec(errMessage);
+
+    if (dateMatch) {
+      const date = dateMatch[0];
+      const text = errMessage.replace(regex, '');
+
+      const reformatDate = GBdate(date).replaceAll('/', ' ');
+
+      return `${reformatDate}${text}`;
+    } else {
+      // Handle the case where regex doesn't match
+      return errMessage;
+    }
+  } else {
+    return errMessage;
+  }
+};
+
 export const checkErrorMsgs = (errorMsgs = [], fieldIdentity = '', fieldElement = '') => {
   return errorMsgs.find(
     element =>


### PR DESCRIPTION
I've added a util function to check the date format with a regex. Then if it that matches it sends the date to the 'GBDate' function to re-format it into the correct order and removes the '/' in-between the day month and year. 

E.g. it takes the error message - '2023-Feb-27 is not a valid date value' and converts it to - '27 Feb 2023 is not a valid date value'. 

I've added the util to the Fieldset and ErrorSummary components.