### PR TITLE
feat:US12545 - Hiding remove link

### DIFF
--- a/src/components/custom-sdk/template/HMRC_ODX_GDSSummaryCard/index.tsx
+++ b/src/components/custom-sdk/template/HMRC_ODX_GDSSummaryCard/index.tsx
@@ -4,14 +4,12 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { GBdate, isSingleEntity } from '../../../helpers/utils';
 import StyledHmrcOdxGdsSummaryCardWrapper from './styles';
-import NotificationBanner from '../../../BaseComponents/NotificationBanner/NotificationBanner';
 
 export default function HmrcOdxGdsSummaryCard(props) {
   const { children, NumCols, sectionHeader, getPConnect, useType } = props;
 
   const containerItemID = getPConnect().getContextName();
-  const [singleEntity, setSingleEntity] = useState(false);
-  const [content, setContent] = useState('');
+  const [pageReference, setPageReference] = useState('');
   const { t } = useTranslation();
   const nCols = parseInt(NumCols, 8);
   const [formElms, setFormElms] = useState<Array<ReactNode>>([]); // Initialize as an empty array of React Nodes
@@ -38,6 +36,7 @@ export default function HmrcOdxGdsSummaryCard(props) {
     const elms: Array<string> = [];
     let finalELms: Array<string> = [];
     const region = children[0] ? children[0].props.getPConnect() : null;
+    setPageReference(region.getPageReference());
     if (region?.getChildren()) {
       region.getChildren().forEach(child => {
         child.getPConnect().setInheritedProp('readOnly', true);
@@ -64,42 +63,6 @@ export default function HmrcOdxGdsSummaryCard(props) {
   }, [formElms]);
 
   const handleOnClick = (action: string) => {
-    let key = '';
-    let checkSingleEntity = false;
-    if (action === t('GDS_ACTION_REMOVE')) {
-      switch (useType) {
-        case '1':
-          key = '.Claim.Children';
-          checkSingleEntity = isSingleEntity(useType, key, action, getPConnect);
-          setSingleEntity(checkSingleEntity);
-          setContent(t('NOTIFICATION_BANNER_CONTENT'));
-          if (checkSingleEntity) return;
-          break;
-        case '2':
-          key = '.Claim.Claimant.Nationalities';
-          checkSingleEntity = isSingleEntity(useType, key, action, getPConnect);
-          setSingleEntity(checkSingleEntity);
-          setContent(t('NOTIFICATION_NATIONALITY_BANNER_CONTENT'));
-          if (checkSingleEntity) return;
-          break;
-        case '3':
-          key = '.Claim.Claimant.CurrentEmployment.CountriesWorkedIn.Countries';
-          checkSingleEntity = isSingleEntity(useType, key, action, getPConnect);
-          setSingleEntity(checkSingleEntity);
-          setContent(t('NOTIFICATION_COUNTRY_BANNER_CONTENT'));
-          if (checkSingleEntity) return;
-          break;
-        case '4':
-          key = '.Claim.Claimant.OtherNames';
-          checkSingleEntity = isSingleEntity(useType, key, action, getPConnect);
-          setSingleEntity(checkSingleEntity);
-          setContent(t('NOTIFICATION_NAME_BANNER_CONTENT'));
-          if (checkSingleEntity) return;
-          break;
-        default:
-          break;
-      }
-    }
     switch (action) {
       case t('GDS_ACTION_REMOVE'):
         getPConnect().setValue('.UserActions', 'Remove');
@@ -123,23 +86,23 @@ export default function HmrcOdxGdsSummaryCard(props) {
           gap: 2
         }}
       >
-        {singleEntity && <NotificationBanner content={content} />}
-
         <div className='govuk-summary-card'>
           <div className='govuk-summary-card__title-wrapper'>
             <h2 className='govuk-summary-card__title'>{itemName}</h2>
             <ul className='govuk-summary-card__actions'>
-              <li className='govuk-summary-card__action'>
-                {' '}
-                <a
-                  className='govuk-link'
-                  href='#'
-                  onClick={() => handleOnClick(t('GDS_ACTION_REMOVE'))}
-                >
-                  {t('GDS_ACTION_REMOVE')}
-                  <span className='govuk-visually-hidden'> {childName}</span>
-                </a>
-              </li>
+              {!isSingleEntity(pageReference, getPConnect) && (
+                <li className='govuk-summary-card__action remove-link'>
+                  {' '}
+                  <a
+                    className='govuk-link'
+                    href='#'
+                    onClick={() => handleOnClick(t('GDS_ACTION_REMOVE'))}
+                  >
+                    {t('GDS_ACTION_REMOVE')}
+                    <span className='govuk-visually-hidden'> {childName}</span>
+                  </a>
+                </li>
+              )}
               <li className='govuk-summary-card__action'>
                 {' '}
                 <a

--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -79,13 +79,14 @@ export const isUnAuthJourney = () => {
   const caseType = PCore.getStoreValue('.CaseType', 'caseInfo.content', context);
   return caseType === 'Unauth';
 };
-export const isSingleEntity = (useType: string, key: string, action: any, getPConnect: any) => {
+
+export const isSingleEntity = (propReference: string, getPConnect) => {
   const containerName = getPConnect().getContainerName();
   const context = PCore.getContainerUtils().getActiveContainerItemContext(
     `${PCore.getConstants().APP.APP}/${containerName}`
   );
 
-  const count = PCore.getStoreValue(key, 'caseInfo.content', context)?.length;
+  const count = PCore.getStoreValue(propReference.split('[')[0], 'caseInfo.content', context)?.length;
 
   if (typeof count !== 'undefined' && count === 1) return true;
 };


### PR DESCRIPTION
- When there is only one item on the add more details screen for Country, Nationality, Name and Children, remove button should not be displayed to the user.
- Removed existing important banner message (upon clicking remove button on the last item)

Screenshots - 
**Nationality** - For Two cards 
![image](https://github.com/norm-l/odx/assets/154439730/20ca1026-12d0-4539-b672-ecbd1a0a15ac)

**Nationality** - For only one card
![image](https://github.com/norm-l/odx/assets/154439730/82f48114-15f9-4275-9148-99896876304d)

**Names**
![image](https://github.com/norm-l/odx/assets/154439730/c3314ce4-5c5f-4356-9801-42a9d93df762)
![image](https://github.com/norm-l/odx/assets/154439730/06cb805b-3a49-4819-b2f5-ce6259b9863e)





