### PR TITLE
Bug 7920 - Error messages not getting cleared when user goes back. 

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -183,6 +183,7 @@ export default function Assignment(props) {
       PCore.getMessageManager().clearMessages({
         property: error.message.clearMessageProperty,
         pageReference: error.message.pageRef,
+        category: 'Property',
         context: containerID,
         type: 'error'
       })

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -65,6 +65,7 @@ export default function Assignment(props) {
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
   const [serviceShutteredStatus, setServiceShutteredStatus] = useState(serviceShuttered);
+  const [messagesToClear, setMessagesToClear] = useState([]);
 
   const _containerName = getPConnect().getContainerName();
   const context = getPConnect().getContextName();
@@ -130,12 +131,19 @@ export default function Assignment(props) {
           type: 'error'
         });
         let validatemessage = '';
+        // New array for the messages in case they need to be cleared when user clicks back button.
+        let clearMessageList = [];
         if (errorVal.length > 0) {
           errorVal.forEach(element => {
             validatemessage =
               validatemessage + (validatemessage.length > 0 ? '. ' : '') + element.message;
+            clearMessageList.push(element);
+            return clearMessageList;
           });
         }
+
+        // Add the messages to be cleared to a new array
+        setMessagesToClear([...clearMessageList]);
 
         if (validatemessage) {
           const formattedPropertyName = fieldC11nEnv?.getStateProps()?.value?.split('.')?.pop();
@@ -170,6 +178,17 @@ export default function Assignment(props) {
       }, []);
 
     setErrorMessages([...errorStateProps]);
+  }
+
+  function clearErrors() {
+    messagesToClear.forEach(message =>
+      PCore.getMessageManager().clearMessages({
+        property: message.property,
+        pageReference: message.pageReference,
+        context: message.context,
+        type: message.type
+      })
+    );
   }
 
   // Fetches and filters any validatemessages on fields on the page, ordering them correctly based on the display order set in DefaultForm.
@@ -209,6 +228,8 @@ export default function Assignment(props) {
       switch (sAction) {
         case 'navigateToStep': {
           const navigatePromise = navigateToStep('previous', itemKey);
+
+          clearErrors();
 
           navigatePromise
             .then(() => {

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -25,6 +25,8 @@ import StoreContext from '@pega/react-sdk-components/lib/bridge/Context/StoreCon
 export interface ErrorMessageDetails {
   message: string;
   fieldId: string;
+  pageRef: string;
+  clearMessageProperty: string;
 }
 
 interface OrderedErrorMessage {
@@ -65,7 +67,6 @@ export default function Assignment(props) {
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
   const [serviceShutteredStatus, setServiceShutteredStatus] = useState(serviceShuttered);
-  const [messagesToClear, setMessagesToClear] = useState([]);
 
   const _containerName = getPConnect().getContainerName();
   const context = getPConnect().getContextName();
@@ -131,21 +132,16 @@ export default function Assignment(props) {
           type: 'error'
         });
         let validatemessage = '';
-        // New array for the messages in case they need to be cleared when user clicks back button.
-        let clearMessageList = [];
         if (errorVal.length > 0) {
           errorVal.forEach(element => {
             validatemessage =
               validatemessage + (validatemessage.length > 0 ? '. ' : '') + element.message;
-            clearMessageList.push(element);
-            return clearMessageList;
           });
         }
 
-        // Add the messages to be cleared to a new array
-        setMessagesToClear([...clearMessageList]);
-
         if (validatemessage) {
+          const clearMessageProperty = fieldC11nEnv?.getStateProps()?.value;
+          const pageRef = fieldC11nEnv?.getPageReference();
           const formattedPropertyName = fieldC11nEnv?.getStateProps()?.value?.split('.')?.pop();
           let fieldId =
             fieldC11nEnv.getStateProps().fieldId ||
@@ -169,7 +165,9 @@ export default function Assignment(props) {
           acc.push({
             message: {
               message: removeRedundantString(validatemessage),
-              fieldId
+              pageRef,
+              fieldId,
+              clearMessageProperty
             },
             displayOrder: fieldComponent.props.displayOrder
           });
@@ -181,12 +179,12 @@ export default function Assignment(props) {
   }
 
   function clearErrors() {
-    messagesToClear.forEach(message =>
+    errorMessages.forEach(error =>
       PCore.getMessageManager().clearMessages({
-        property: message.property,
-        pageReference: message.pageReference,
-        context: message.context,
-        type: message.type
+        property: error.message.clearMessageProperty,
+        pageReference: error.message.pageRef,
+        context: containerID,
+        type: 'error'
       })
     );
   }


### PR DESCRIPTION
I've added some fields into each error message object that is created. I've then added function which runs the clearMessages() method on each error when the user clicks the back/previous link.