### PR TITLE
Bug-7984: Fixed rendering order issue

### DIFF
--- a/src/components/BaseComponents/FormGroup/FormGroup.tsx
+++ b/src/components/BaseComponents/FormGroup/FormGroup.tsx
@@ -71,7 +71,7 @@ export default function FormGroup({
           {removeRedundantString(errMessage)}
         </p>
       )}
-      {children}
+      <div>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
Some of the pages where Autocomplete component is used, React is not rendering the component in proper order when user come from portal page after clicking cancel or save and come back later. 

We have tried multiple solution like adding <></> but only adding `<div>` works.