### PR TITLE
Us 12668 - Remove "Cancel" button and change "Continue" to be "Save and continue" on auth journey only

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -52,6 +52,7 @@
 
   "APPLICATION_RECEIVED": "Cais am Fudd-dal Plant wedi dod i law",
   "CLOSE_CLAIM": "Close claim",
+  "SAVE_AND_CONTINUE": "Save and continue",
   "YOUR_REF_NUMBER": "Your reference number",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Postiwch eich dogfennau ategol",
   "WHAT_YOU_NEED_TO_DO_NOW": "Yr hyn y mae angen i chi ei wneud nawr",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -52,6 +52,7 @@
 
   "APPLICATION_RECEIVED": "Application for Child Benefit received",
   "CLOSE_CLAIM": "Close claim",
+  "SAVE_AND_CONTINUE": "Save and continue",
   "YOUR_REF_NUMBER": "Your reference number",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Post your supporting documents",
   "WHAT_YOU_NEED_TO_DO_NOW": "What you need to do now",

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -26,9 +26,7 @@ export default function ActionButtons(props) {
               key={mButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {isUnAuth
-                ? localizedVal(mButton.name, localeCategory)
-                : mButton.name === 'Continue'
+              {!isUnAuth && mButton.name === 'Continue'
                 ? t('SAVE_AND_CONTINUE')
                 : localizedVal(mButton.name, localeCategory)}
             </Button>

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -30,23 +30,24 @@ export default function ActionButtons(props) {
             </Button>
           ) : null
         )}
-        {arSecondaryButtons.map(sButton =>
-          sButton.actionID !== 'back' &&
-          sButton.name !== 'Hidden' &&
-          sButton.name.indexOf('Save') === -1 ? (
-            <Button
-              variant='secondary'
-              onClick={e => {
-                e.target.blur();
-                _onButtonPress(sButton.jsAction, 'secondary');
-              }}
-              key={sButton.actionID}
-              attributes={{ type: 'button' }}
-            >
-              {isUnAuth ? t('CLOSE_CLAIM') : localizedVal(sButton.name, localeCategory)}
-            </Button>
-          ) : null
-        )}
+        {isUnAuth &&
+          arSecondaryButtons.map(sButton =>
+            sButton.actionID !== 'back' &&
+            sButton.name !== 'Hidden' &&
+            sButton.name.indexOf('Save') === -1 ? (
+              <Button
+                variant='secondary'
+                onClick={e => {
+                  e.target.blur();
+                  _onButtonPress(sButton.jsAction, 'secondary');
+                }}
+                key={sButton.actionID}
+                attributes={{ type: 'button' }}
+              >
+                {t('CLOSE_CLAIM')}
+              </Button>
+            ) : null
+          )}
       </div>
 
       {!isUnAuth &&

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -26,7 +26,11 @@ export default function ActionButtons(props) {
               key={mButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {isUnAuth ? localizedVal(mButton.name, localeCategory) : t('SAVE_AND_CONTINUE')}
+              {isUnAuth
+                ? localizedVal(mButton.name, localeCategory)
+                : mButton.actionID === 'submit'
+                ? localizedVal(mButton.name, localeCategory)
+                : t('SAVE_AND_CONTINUE')}
             </Button>
           ) : null
         )}

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -26,7 +26,7 @@ export default function ActionButtons(props) {
               key={mButton.actionID}
               attributes={{ type: 'button' }}
             >
-              {localizedVal(mButton.name, localeCategory)}
+              {isUnAuth ? localizedVal(mButton.name, localeCategory) : t('SAVE_AND_CONTINUE')}
             </Button>
           ) : null
         )}

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -28,9 +28,9 @@ export default function ActionButtons(props) {
             >
               {isUnAuth
                 ? localizedVal(mButton.name, localeCategory)
-                : mButton.actionID === 'submit'
-                ? localizedVal(mButton.name, localeCategory)
-                : t('SAVE_AND_CONTINUE')}
+                : mButton.name === 'Continue'
+                ? t('SAVE_AND_CONTINUE')
+                : localizedVal(mButton.name, localeCategory)}
             </Button>
           ) : null
         )}


### PR DESCRIPTION
Currently, the claimant has to click on 'Continue' button to save and go to the next page. To make it more complaint with GDS, the Continue button has to be amended as 'Save and continue' and 'Cancel' button will be removed for auth hourney.

Note: Continue button will only be amended with 'Save and continue' and the action for the button will not be changed. This is only for Auth journey. 