### PR TITLE
Bug 7961 & Bug 8028 Re-style the claim again button and fix the multi screens issue

### DIFF
--- a/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
@@ -13,7 +13,7 @@ export default function DeleteAnswers({ hasSessionTimedOut }) {
           ? t('FOR_YOUR_SECURITY_WE_DELETED_YOUR_CLAIM')
           : t('YOU_DELETED_YOUR_CLAIM')}
       </h1>
-      <Button variant='start'>{t('START_CLAIM_AGAIN')}</Button>
+      <Button>{t('START_CLAIM_AGAIN')}</Button>
       <h2 className='govuk-heading-m'>{t('BEFORE_YOU_GO')}</h2>
       <p className='govuk-body'>{t('YOUR_FEEDBACK_HELPS_US_MAKES_OUR_SERVICE_BETTER')}.</p>
       <p className='govuk-body'>

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -44,7 +44,7 @@ export default function UnAuthChildBenefitsClaim() {
   const [serviceNotAvailable, setServiceNotAvailable] = useState(false);
   const [shutterServicePage, setShutterServicePage] = useState(false);
   const [hasSessionTimedOut, setHasSessionTimedOut] = useState(true);
-  const [showDeletePage, setShowDeletePage] = useState(false);  
+  const [showDeletePage, setShowDeletePage] = useState(false);
   const [assignmentPConn, setAssignmentPConn] = useState(null);
   const history = useHistory();
   const [caseId, setCaseId] = useState('');
@@ -83,10 +83,13 @@ export default function UnAuthChildBenefitsClaim() {
       resetAppDisplay();
       setShowPega(true);
 
-
       let startingFields = {};
-      startingFields = {NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0,2) || 'en'};
-      PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {startingFields});
+      startingFields = {
+        NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0, 2) || 'en'
+      };
+      PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
+        startingFields
+      });
     }
     setShowStartPage(false);
   }
@@ -117,6 +120,7 @@ export default function UnAuthChildBenefitsClaim() {
     setShowTimeoutModal(false);
     setShowStartPage(false);
     setShowPega(false);
+    setShowResolutionScreen(false);
     setShowDeletePage(true);
   }
 
@@ -225,7 +229,12 @@ export default function UnAuthChildBenefitsClaim() {
 
     const theComp = (
       <StoreContext.Provider
-        value={{ store: PCore.getStore(), displayOnlyFA: true, isMashup: true, setAssignmentPConnect: setAssignmentPConn }}
+        value={{
+          store: PCore.getStore(),
+          displayOnlyFA: true,
+          isMashup: true,
+          setAssignmentPConnect: setAssignmentPConn
+        }}
       >
         {thePConnObj}
       </StoreContext.Provider>
@@ -436,7 +445,15 @@ export default function UnAuthChildBenefitsClaim() {
 
   return (
     <>
-      <AppHeader appname={t('CLAIM_CHILD_BENEFIT')} hasLanguageToggle isPegaApp={bShowPega} languageToggleCallback={toggleNotificationProcess({en:'SwitchLanguageToEnglish', cy:'SwitchLanguageToWelsh'}, assignmentPConn)}/>
+      <AppHeader
+        appname={t('CLAIM_CHILD_BENEFIT')}
+        hasLanguageToggle
+        isPegaApp={bShowPega}
+        languageToggleCallback={toggleNotificationProcess(
+          { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
+          assignmentPConn
+        )}
+      />
 
       <div className='govuk-width-container'>
         <div id='pega-part-of-page'>


### PR DESCRIPTION
As a part of these bug now we could able to generate the start claim again button with standard gov uk styling.

And we could able to remove confirmation screen appearing on delete answers screen.

![image](https://github.com/norm-l/odx/assets/149078642/85e0770f-740c-4858-94b4-7830516bd782)
