### PR TITLE
BUG-7400: Fixed bug

### DIFF
--- a/src/components/BaseComponents/FormGroup/FieldSet.tsx
+++ b/src/components/BaseComponents/FormGroup/FieldSet.tsx
@@ -41,7 +41,7 @@ export default function FieldSet({
   const describedByIDs: Array<string> = [];
   const hintID = `${name}-hint`;
   const errorID = `${name}-error`;
-  if (hintText) {
+  if (hintTextExists) {
     describedByIDs.push(hintID);
   }
   if (errMessage) {


### PR DESCRIPTION
The fieldset element has an aria-describedby attribute value of "undefined hint". I believe this is a wider issue for all fieldgroups, but this should be resolved by REACT team. If hint is not defined, then the attribute should not be included.