### PR TITLE
US-12854 : Remove close claim button on all Un-Auth screens

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -51,7 +51,6 @@
   "APPLICATION_FOR_CHB_COMPLETE": "Application for Child Benefit complete",
 
   "APPLICATION_RECEIVED": "Cais am Fudd-dal Plant wedi dod i law",
-  "CLOSE_CLAIM": "Close claim",
   "SAVE_AND_CONTINUE": "Save and continue",
   "YOUR_REF_NUMBER": "Your reference number",
 

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -51,7 +51,6 @@
   "APPLICATION_FOR_CHB_COMPLETE": "Application for Child Benefit complete",
 
   "APPLICATION_RECEIVED": "Application for Child Benefit received",
-  "CLOSE_CLAIM": "Close claim",
   "SAVE_AND_CONTINUE": "Save and continue",
   "YOUR_REF_NUMBER": "Your reference number",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Post your supporting documents",

--- a/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
+++ b/src/components/override-sdk/infra/ActionButtons/ActionButtons.tsx
@@ -32,24 +32,6 @@ export default function ActionButtons(props) {
             </Button>
           ) : null
         )}
-        {isUnAuth &&
-          arSecondaryButtons.map(sButton =>
-            sButton.actionID !== 'back' &&
-            sButton.name !== 'Hidden' &&
-            sButton.name.indexOf('Save') === -1 ? (
-              <Button
-                variant='secondary'
-                onClick={e => {
-                  e.target.blur();
-                  _onButtonPress(sButton.jsAction, 'secondary');
-                }}
-                key={sButton.actionID}
-                attributes={{ type: 'button' }}
-              >
-                {t('CLOSE_CLAIM')}
-              </Button>
-            ) : null
-          )}
       </div>
 
       {!isUnAuth &&


### PR DESCRIPTION
As per the latest discussion between PO's and BA's , we have a user story where we need to remove close claim button for all the Un-Auth screens.

Deleted the close claim button rendering code and also the constants related to text 'close claim' have been removed from both en.json and cy.json.