### PR TITLE
fix: BUG-7914 - font size issue on 'remove' screens

### DIFF
--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.css
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.css
@@ -1,6 +1,6 @@
 /***** CSS styles specific to default form hooks                   *****/
 /***** added through extended Pega properties                      *****/
-/***** 1. u-gdsSummaryCard - used on child summary screen            *****/
+/***** 1. u-gdsSummaryCard - used on child summary screen          *****/
 /***** 2. u-childRemove - used on the confirm child removal screen *****/
 
 /* FORM HOOK - u-gdsSummaryCard */
@@ -37,6 +37,10 @@
 }
 
 /* FORM HOOK - u-childRemove */
+
+.u-childRemove {
+  font-size: 1.1875rem;
+}
 
 .u-childRemove .govuk-main-wrapper {
   padding-top: 0;


### PR DESCRIPTION
Below screens are having issue - 
- Remove your other last name or family name
- Confirm and remove nationality
- Confirm and remove partner nationality
- Confirm and remove country (after In the last 3 months, which countries have you worked in?)
- Confirm and remove country (after In the last 3 months, which countries did you receive benefits in?
- Confirm and remove country (after In the last 3 months, which countries has your partner worked in?
- Confirm and remove country (after In the last 3 months, which countries did your partner receive benefits in?
- Remove the child's other name

Here are few screenshots after fix - 
- Remove your other last name or family name
![image](https://github.com/norm-l/odx/assets/154439730/2d3a7105-3e1d-4e43-a7b2-f2d60cde0d07)

- Confirm and remove nationality
![image](https://github.com/norm-l/odx/assets/154439730/29320922-76d0-4b37-bade-019c023e6575)

- Confirm and remove country (after In the last 3 months, which countries have you worked in?)
![image](https://github.com/norm-l/odx/assets/154439730/bd59fbe4-54cc-4b41-b449-9f342bc65504)

- Remove the child's other name
![image](https://github.com/norm-l/odx/assets/154439730/0aba0dbd-3863-4edc-81a3-e2c0592362e1)

- Also fixed for multiple child remove scenario
![image](https://github.com/norm-l/odx/assets/154439730/6270b59e-d726-4b54-836e-8ea65b4c9c84)




