### PR TITLE
Bug 7798

### DIFF
--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -50,17 +50,13 @@ export default function DefaultForm(props) {
 
   function settingTargetForAnchorTag() {
     const instructionDiv = document.getElementById('instructions');
-    const keyText = t('OPENS_IN_NEW_TAB');
+    const keyTexts = [t('OPENS_IN_NEW_TAB'), '(opens in a new tab)', '(yn agor mewn tab newydd)'];
 
     if (instructionDiv) {
       const elementsArr = instructionDiv.querySelectorAll('a');
       // @ts-ignore
       for (const ele of elementsArr) {
-        if (
-          ele.innerHTML.includes(keyText) ||
-          ele.innerHTML.includes('(opens in a new tab)') ||
-          ele.innerHTML.includes('(yn agor mewn tab newydd)')
-        ) {
+        if (keyTexts.some(text => ele.innerHTML.includes(text))) {
           ele.setAttribute('target', '_blank');
           ele.setAttribute('rel', 'noreferrer noopener');
         }

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -55,7 +55,11 @@ export default function DefaultForm(props) {
       const elementsArr = instructionDiv.querySelectorAll('a');
       // @ts-ignore
       for (const ele of elementsArr) {
-        if (ele.innerHTML.includes(keyText) || ele.hasAttribute('target')) {
+        if (
+          ele.innerHTML.includes(keyText) ||
+          ele.innerHTML.includes('(opens in a new tab)') ||
+          ele.innerHTML.includes('(yn agor mewn tab newydd)')
+        ) {
           ele.setAttribute('target', '_blank');
           ele.setAttribute('rel', 'noreferrer noopener');
         }

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -55,7 +55,7 @@ export default function DefaultForm(props) {
       const elementsArr = instructionDiv.querySelectorAll('a');
       // @ts-ignore
       for (const ele of elementsArr) {
-        if (ele.innerHTML.includes(keyText)) {
+        if (ele.innerHTML.includes(keyText) || ele.hasAttribute('target')) {
           ele.setAttribute('target', '_blank');
           ele.setAttribute('rel', 'noreferrer noopener');
         }


### PR DESCRIPTION
Because currently the target attribute is added based on matching exact text when there is a variation of that text e.g. "(opens in new tab)" vs "(opens in a new tab)" I have changed the code that adds the attributes to look for a regex pattern instead. 