### PR TITLE
Bug - 8050 : fix related to case reference number

### DIFF
--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -46,7 +46,7 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
         }
         setLoading(false);
         setDocumentList(listData.DocumentContentHTML);
-        if (listData.DocumentContentHTML.includes('data-ninopresent')) {
+        if (listData.DocumentContentHTML.includes('data-ninopresent="false"')) {
           setIsCaseRefRequired(true);
         }
       })


### PR DESCRIPTION
This Bug fix is regarding with confirmation screen , where for an Un-Auth claim we are getting case reference number appearing even when selected Do you have NINO as 'Yes'.