### PR TITLE
Bug-8132 : removal of back link in choose a claim service page

### DIFF
--- a/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
+++ b/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
@@ -47,7 +47,7 @@ export default function AreYouSureToContinueWithoutSignIn() {
       if (selectedOptionValue === 'yes') {
         history.push('/ua');
       } else {
-        window.location.href = 'https://www.access.service.gov.uk/login/signin/creds';
+        window.location.href = '/';
       }
     } else {
       setErrorMsg(t('SELECT_YES_IF_YOU_WANT_TO_CONTINUE_WO_SIGN_IN'));

--- a/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
+++ b/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
@@ -45,7 +45,9 @@ export default function AreYouSureToContinueWithoutSignIn() {
       // todo - both yes and no redirection link to be confirmed - not mentioned explicitly in story
       const selectedOptionValue = selectedOption.getAttribute('value');
       if (selectedOptionValue === 'yes') {
-        history.push('/ua');
+        window.location.assign(
+          'https://www.tax.service.gov.uk/fill-online/claim-child-benefit/task-list'
+        );
       } else {
         window.location.href = '/';
       }

--- a/src/samples/StaticPages/ChooseClaimService/index.tsx
+++ b/src/samples/StaticPages/ChooseClaimService/index.tsx
@@ -5,7 +5,6 @@ import AppFooter from '../../../components/AppComponents/AppFooter';
 import { useTranslation } from 'react-i18next';
 import MainWrapper from '../../../components/BaseComponents/MainWrapper';
 import RadioButtons from '../../../components/BaseComponents/RadioButtons/RadioButtons';
-import Button from '../../../components/BaseComponents/Button/Button';
 import '../../../../assets/css/appStyles.scss';
 import StaticPageErrorSummary from '../ErrorSummary';
 import setPageTitle from '../../../components/helpers/setPageTitleHelpers';
@@ -85,12 +84,6 @@ export default function RecentlyClaimedChildBenefit() {
     <>
       <AppHeader appname={t('CLAIM_CHILD_BENEFIT')} hasLanguageToggle isPegaApp={false} />
       <div className='govuk-width-container'>
-        <Button
-          variant='backlink'
-          onClick={() => history.goBack()}
-          key='RecentlyClaimedBacklink'
-          attributes={{ type: 'link' }}
-        />
         <MainWrapper>
           <StaticPageErrorSummary errorSummary={errorMsg} linkHref={errorHref} />
           <RadioButtons


### PR DESCRIPTION
As a part of this Bug fix , we need to remove back button on page where claimant chooses the journey he want to enter.

Also this one got confirmed from jake and mashuk on triage call.

Also as a part of upcoming release , we are now pointing to MDTP Un-Auth instead of actual Un-Auth