### PR TITLE
Bug 7113 - Getting the header translations from the default form locale reference

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -100,19 +100,17 @@ export default function Assignment(props) {
 
   if (caseInfo?.assignments?.length > 0) {
     containerName = caseInfo.assignments[0].name;
-    // const firstActionId = caseInfo.assignments[0]?.actions[0]?.ID.toUpperCase();
-    // headerLocaleLocation = `${caseInfo.caseTypeID.toUpperCase()}!VIEW!${firstActionId}`;
   }
 
   const headerLocaleLocation = PCore.getStoreValue('localeReference', '', 'app');
 
   useEffect(() => {
-    setHeader(localizedVal(containerName, '', headerLocaleLocation));
-  }, [headerLocaleLocation]);
+    const headerFetch = setTimeout(() => {
+      setHeader(localizedVal(containerName, '', headerLocaleLocation));
+    }, 50);
 
-  // PCore.getAssetLoader().loadAssets(`${headerLocaleLocation}.json`)
-  // .then(setHeader(localizedVal(containerName,'', headerLocaleLocation)))
-  // .catch(console.log('Error'))
+    return () => clearTimeout(headerFetch);
+  }, [headerLocaleLocation]);
 
   useEffect(() => {
     if (children && children.length > 0) {
@@ -403,9 +401,7 @@ export default function Assignment(props) {
             {(!isOnlyFieldDetails.isOnlyField ||
               containerName.toLowerCase().includes('check your answer') ||
               containerName.toLowerCase().includes('declaration')) && (
-              <h1 className='govuk-heading-l'>
-                {localizedVal(containerName, '', headerLocaleLocation)}
-              </h1>
+              <h1 className='govuk-heading-l'>{header}</h1>
             )}
             {shouldRemoveFormTag ? renderAssignmentCard() : <form>{renderAssignmentCard()}</form>}
             <a

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -67,6 +67,7 @@ export default function Assignment(props) {
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
   const [serviceShutteredStatus, setServiceShutteredStatus] = useState(serviceShuttered);
+  const [header, setHeader] = useState('');
 
   const _containerName = getPConnect().getContainerName();
   const context = getPConnect().getContextName();
@@ -94,15 +95,24 @@ export default function Assignment(props) {
   }, [errorMessages]);
 
   let containerName;
-  let headerLocaleLocation;
 
   const caseInfo = thePConn.getDataObject().caseInfo;
 
   if (caseInfo?.assignments?.length > 0) {
     containerName = caseInfo.assignments[0].name;
-    const firstActionId = caseInfo.assignments[0]?.actions[0]?.ID.toUpperCase();
-    headerLocaleLocation = `${caseInfo.caseTypeID.toUpperCase()}!VIEW!${firstActionId}`;
+    // const firstActionId = caseInfo.assignments[0]?.actions[0]?.ID.toUpperCase();
+    // headerLocaleLocation = `${caseInfo.caseTypeID.toUpperCase()}!VIEW!${firstActionId}`;
   }
+
+  const headerLocaleLocation = PCore.getStoreValue('localeReference', '', 'app');
+
+  useEffect(() => {
+    setHeader(localizedVal(containerName, '', headerLocaleLocation));
+  }, [headerLocaleLocation]);
+
+  // PCore.getAssetLoader().loadAssets(`${headerLocaleLocation}.json`)
+  // .then(setHeader(localizedVal(containerName,'', headerLocaleLocation)))
+  // .catch(console.log('Error'))
 
   useEffect(() => {
     if (children && children.length > 0) {

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -111,6 +111,19 @@ export default function DefaultForm(props) {
     }
   }, [instructionExists]);
 
+  // Sets the localeReference property in the store for getting the translated title in Assignment.tsx
+  useEffect(() => {
+    PCore.getStore().dispatch({
+      type: 'SET_PROPERTY',
+      payload: {
+        reference: 'localeReference',
+        value: props.localeReference,
+        context: 'app',
+        isArrayDeepMerge: false
+      }
+    });
+  }, []);
+
   useEffect(() => {
     if (containerName === 'Declaration') {
       // Get current context


### PR DESCRIPTION
Here I am attempting to get the correct location of the header title translations from the nested default form components. 

I'm adding a store value for the locale reference, then using a slight timeout to make sure the store is updated before attempting to retrieve the header translation.  