### PR TITLE
Us 12607 : new changes related to timeout pop on un-auth confirmation screen

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -39,7 +39,7 @@
 
   "APPLICATION_RECEIVED": "Cais am Fudd-dal Plant wedi dod i law",
   "SAVE_AND_CONTINUE": "Cadw ac yn eich blaen",
-  "YOUR_REF_NUMBER": "Your reference number",
+  "YOUR_REF_NUMBER": "Eich cyfeirnod",
   "POST_YOUR_SUPPORTING_DOCUMENTS": "Postiwch eich dogfennau ategol",
   "WHAT_YOU_NEED_TO_DO_NOW": "Yr hyn y mae angen i chi ei wneud nawr",
   "THE_INFO_YOU_HAVE_PROVIDED": "Mae’r wybodaeth a roddwyd gennych wedi’i defnyddio i greu eich ffurflen hawlio Budd-dal Plant",
@@ -51,7 +51,7 @@
   "PRINT_THIS_INFO": "Argraffwch y dudalen hon neu gwnewch nodyn o’r cyfeirnod. Bydd angen hwn arnoch os byddwch yn cysylltu â CThEF neu os bydd CThEF yn gofyn am ragor o wybodaeth.",
 
   "WHAT_HAPPENS_NEXT": "Yr hyn sy’n digwydd nesaf",
-  "WE_HAVE_SENT_YOUR_APPLICATION": "We've sent your application to the Child Benefit Office.",
+  "WE_HAVE_SENT_YOUR_APPLICATION": "Rwyf wedi anfon eich cais i’r Swyddfa Budd-dal Plant.",
   "WE_WILL_TELL_YOU_IN_14_DAYS": "Byddwn yn rhoi gwybod i chi cyn pen 14 diwrnod calendr os yw’ch cais wedi bod yn llwyddiannus.",
   "CONTINUE_CLAIM": "Parhau â’r hawliad",
   "CLAIMS_IN_PROGRESS": "Hawliadau ar y gweill",
@@ -71,7 +71,7 @@
   "THE_HIGH_INCOME_CHB_TAX_CHARGE": "y Tâl Treth Budd-dal Plant Incwm Uchel",
   "ANY_CHANGE_OF_CIRCUMSTANCE": "unrhyw newid mewn amgylchiadau i chi neu eich plentyn a allai effeithio ar eich hawliad",
 
-  "CHILD_NAME": "Child name",
+  "CHILD_NAME": "Enw’r plentyn",
   "DATE_OF_BIRTH": "Dyddiad geni",
   "CREATED_DATE": "Dyddiad creu",
   "YOU_STILL_NEED_TO_SAVE_YOUR_PROGRESS": "Mae angen i chi gadw eich cynnydd o hyd. Os byddwch yn allgofnodi heb ei gadw, byddwch yn colli’ch cynnydd.",
@@ -125,11 +125,11 @@
   "COOKIE_AWSALB_DESCRIPTION": "Defnyddir hyn i helpu i reoli’r traffig rhwng porwr gwe ymwelwr a gweinydd y rhaglen sy’n cynnal gwasanaethau CThEF.",
   "COOKIE_AWSALBCORS_DESCRIPTION": "Defnyddir hyn i helpu i reoli’r traffig rhwng porwr gwe ymwelwr a gweinydd y rhaglen sy’n cynnal gwasanaethau CThEF.",
   "COOKIE_JSESSIONID_DESCRIPTION": "Defnyddir hyn i adnabod gwybodaeth am sesiwn yr ymwelwr, a’r wybodaeth honno yn ymwneud â’r gwasanaeth sy’n cael ei ddefnyddio.",
-  
+
   "COOKIE_PEGAODXEI_DESCRIPTION": "This is used to identify the session ID of a user not using Government Gateway.",
   "COOKIE_PEGAODXDI_DESCRIPTION": "This is used to uniquely identify a device that has interacted with HMRC services and is used for internal security auditing.",
   "COOKIE_AKA_A2_DESCRIPTION": "This Akamai cookie is used to help speed up content delivery on websites using adaptive acceleration.",
-  
+
   "COOKIE_FIND_OUT_MORE": "Dysgwch ragor am gwcis ar wasanaethau CThEF",
   "GDS_INFO_IMPORTANT": "Pwysig",
   "GDS_INFO_SUCCESS": "Llwyddiant",
@@ -243,7 +243,7 @@
   "CHECK_CLAIM_APPROVED": "I wirio os yw’ch hawliad am Fudd-dal Plant wedi’i gymeradwyo, gallwch fwrw golwg dros eich tystiolaeth o hawl. ",
   "YOU_NEED_TO_SIGN_IN_TO_ACCESS_INFO": "Bydd angen i chi mewngofnodi i gael at yr wybodaeth hon. Os nad oes gennych fanylion mewngofnodi, gallwch eu creu (yn agor tab newydd).",
   "EXCLUSIVEOPTION_OR": "neu",
-  "AUTOMATICALLY_CLOSE_IN": "This page will automatically close in",
-  "STAY_ON_THIS_PAGE": "Stay on this page",
-  "EXIT_THIS_PAGE": "Exit this page"
+  "AUTOMATICALLY_CLOSE_IN": "Bydd y dudalen hon yn cau’n awtomatig mewn",
+  "STAY_ON_THIS_PAGE": "Aros ar y dudalen hon",
+  "EXIT_THIS_PAGE": "Gadael y dudalen hon"
 }

--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -235,5 +235,8 @@
   "CHECK_CLAIM_REPLY": "wirio pryd y gallwch ddisgwyl ymateb i’ch hawliad (yn agor tab newydd).",
   "CHECK_CLAIM_APPROVED": "I wirio os yw’ch hawliad am Fudd-dal Plant wedi’i gymeradwyo, gallwch fwrw golwg dros eich tystiolaeth o hawl. ",
   "YOU_NEED_TO_SIGN_IN_TO_ACCESS_INFO": "Bydd angen i chi mewngofnodi i gael at yr wybodaeth hon. Os nad oes gennych fanylion mewngofnodi, gallwch eu creu (yn agor tab newydd).",
-  "EXCLUSIVEOPTION_OR": "neu"
+  "EXCLUSIVEOPTION_OR": "neu",
+  "AUTOMATICALLY_CLOSE_IN": "This page will automatically close in",
+  "STAY_ON_THIS_PAGE": "Stay on this page",
+  "EXIT_THIS_PAGE": "Exit this page"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -235,5 +235,8 @@
   "CHECK_CLAIM_REPLY": "check when you can expect a reply to your claim (opens in new tab).",
   "CHECK_CLAIM_APPROVED": "To check if your claim for Child Benefit has been approved, you can view your proof of entitlement. ",
   "YOU_NEED_TO_SIGN_IN_TO_ACCESS_INFO": "You will need to sign in to access this information. If you do not have sign in details, you can create them (opens in new tab).",
-  "EXCLUSIVEOPTION_OR": "or"
+  "EXCLUSIVEOPTION_OR": "or",
+  "AUTOMATICALLY_CLOSE_IN": "This page will automatically close in",
+  "STAY_ON_THIS_PAGE": "Stay on this page",
+  "EXIT_THIS_PAGE": "Exit this page"
 }

--- a/src/components/AppComponents/TimeoutPopup/index.tsx
+++ b/src/components/AppComponents/TimeoutPopup/index.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
 export default function TimeoutPopup(props) {
-  const { show, staySignedinHandler, signoutHandler, isAuthorised } = props;
+  const { show, staySignedinHandler, signoutHandler, isAuthorised, isConfirmationPage } = props;
   const staySignedInCallback = useCallback(
     event => {
       if (event.key === 'Escape') staySignedinHandler();
@@ -24,6 +24,60 @@ export default function TimeoutPopup(props) {
       window.removeEventListener('keydown', staySignedInCallback);
     };
   }, [show]);
+  const unAuthTimeoutPopupContent = () => {
+    return (
+      <div>
+        <h1 id='govuk-timeout-heading' className='govuk-heading-m push--top'>
+          {t('FOR_YOUR_SECURITY')}
+        </h1>
+
+        <p className='govuk-body'>
+          {t('WE_WILL_DELETE_YOUR_CLAIM')}
+          <span className='govuk-!-font-weight-bold'> {t('2_MINUTES')}.</span>
+        </p>
+
+        <div className='govuk-button-group govuk-!-padding-top-4'>
+          <Button type='button' onClick={staySignedinHandler}>
+            {t('CONTINUE_CLAIM')}
+          </Button>
+
+          <a id='modal-staysignin-btn' className='govuk-link' href='#' onClick={signoutHandler}>
+            {t('DELETE_YOUR_CLAIM')}
+          </a>
+        </div>
+      </div>
+    );
+  };
+  const unAuthTimeoutPopupContentForConfirmationPage = () => {
+    return (
+      <div>
+        <h1 id='govuk-timeout-heading' className='govuk-heading-m push--top'>
+          {t('FOR_YOUR_SECURITY')}
+        </h1>
+
+        <p className='govuk-body'>
+          {t('AUTOMATICALLY_CLOSE_IN')}
+          <span className='govuk-!-font-weight-bold'> {t('2_MINUTES')}.</span>
+        </p>
+
+        <div className='govuk-button-group govuk-!-padding-top-4'>
+          <Button type='button' onClick={staySignedinHandler}>
+            {t('STAY_ON_THIS_PAGE')}
+          </Button>
+
+          <a id='modal-staysignin-btn' className='govuk-link' href='#' onClick={signoutHandler}>
+            {t('EXIT_THIS_PAGE')}
+          </a>
+        </div>
+      </div>
+    );
+  };
+
+  const renderUnAuthPopupContent = () => {
+    return isConfirmationPage
+      ? unAuthTimeoutPopupContentForConfirmationPage()
+      : unAuthTimeoutPopupContent();
+  };
 
   return (
     <Modal show={show} id='timeout-popup'>
@@ -47,24 +101,7 @@ export default function TimeoutPopup(props) {
           </div>
         </div>
       ) : (
-        <div>
-          <h1 id='govuk-timeout-heading' className='govuk-heading-m push--top'>
-            {t('FOR_YOUR_SECURITY')}
-          </h1>
-          <p className='govuk-body'>
-            {t('WE_WILL_DELETE_YOUR_CLAIM')}
-            <span className='govuk-!-font-weight-bold'> {t('2_MINUTES')}.</span>
-          </p>
-          <div className='govuk-button-group govuk-!-padding-top-4'>
-            <Button type='button' onClick={staySignedinHandler}>
-              {t('CONTINUE_CLAIM')}
-            </Button>
-
-            <a id='modal-staysignin-btn' className='govuk-link' href='#' onClick={signoutHandler}>
-              {t('DELETE_YOUR_CLAIM')}
-            </a>
-          </div>
-        </div>
+        renderUnAuthPopupContent()
       )}
     </Modal>
   );
@@ -74,5 +111,6 @@ TimeoutPopup.propTypes = {
   show: PropTypes.bool,
   staySignedinHandler: PropTypes.func,
   signoutHandler: PropTypes.func,
-  isAuthorised: PropTypes.bool
+  isAuthorised: PropTypes.bool,
+  isConfirmationPage: PropTypes.bool
 };

--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -48,10 +48,16 @@ export const initTimeout = (showTimeoutModal, deleteData, isAuthorised, isConfir
 // Sends 'ping' to pega to keep session alive and then initiates the timeout
 export function staySignedIn(
   setShowTimeoutModal,
+  claimsListApi,
   deleteData = null,
   isAuthorised = false,
+  refreshSignin = true,
   isConfirmationPage = false
 ) {
+  if (refreshSignin && !!claimsListApi) {
+    // @ts-ignore
+    PCore.getDataPageUtils().getDataAsync(claimsListApi, 'root');
+  }
   setShowTimeoutModal(false);
   initTimeout(setShowTimeoutModal, deleteData, isAuthorised, isConfirmationPage);
 }

--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -33,9 +33,12 @@ export const initTimeout = (showTimeoutModal, deleteData, isAuthorised, isConfir
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
       if (!isAuthorised && !isConfirmationPage) {
+        // if the journey is not authorized or from confirmation page , the claim data gets deleted
         deleteData();
         clearTimer();
       } else {
+        // the logout case executes when entire timeout occurs after confirmation page or user clicks
+        // exit survey link in pop after confirmation page
         logout();
       }
     }, milisecondsTilSignout);

--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -32,11 +32,11 @@ export const initTimeout = (showTimeoutModal, deleteData, isAuthorised, isConfir
     // TODO - unauth and sessiontimeout functionality to be implemented
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
-      if (isAuthorised || isConfirmationPage) {
-        logout();
-      } else {
+      if (!isAuthorised && !isConfirmationPage) {
         deleteData();
         clearTimer();
+      } else {
+        logout();
       }
     }, milisecondsTilSignout);
   }, milisecondsTilWarning);

--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -20,12 +20,7 @@ export function clearTimer() {
   clearTimeout(signoutTimeout);
 }
 
-export const initTimeout = (
-  showTimeoutModal,
-  deleteData,
-  isAuthorised,
-  isConfirmationPage = false
-) => {
+export const initTimeout = (showTimeoutModal, deleteData, isAuthorised, isConfirmationPage) => {
   // TODO - isAuthorised to be replaced by caseType from pega
   // Fetches timeout length config
   settingTimer();
@@ -37,12 +32,11 @@ export const initTimeout = (
     // TODO - unauth and sessiontimeout functionality to be implemented
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
-      if (!isAuthorised && !isConfirmationPage) {
+      if (isAuthorised || isConfirmationPage) {
+        logout();
+      } else {
         deleteData();
         clearTimer();
-        // session ends and deleteData() (pega)
-      } else {
-        logout();
       }
     }, milisecondsTilSignout);
   }, milisecondsTilWarning);
@@ -51,15 +45,10 @@ export const initTimeout = (
 // Sends 'ping' to pega to keep session alive and then initiates the timeout
 export function staySignedIn(
   setShowTimeoutModal,
-  claimsListApi,
   deleteData = null,
   isAuthorised = false,
-  refreshSignin = true
+  isConfirmationPage = false
 ) {
-  if (refreshSignin && claimsListApi.length > 0) {
-    // @ts-ignore
-    PCore.getDataPageUtils().getDataAsync(claimsListApi, 'root');
-  }
   setShowTimeoutModal(false);
-  initTimeout(setShowTimeoutModal, deleteData, isAuthorised);
+  initTimeout(setShowTimeoutModal, deleteData, isAuthorised, isConfirmationPage);
 }

--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -20,7 +20,12 @@ export function clearTimer() {
   clearTimeout(signoutTimeout);
 }
 
-export const initTimeout = (showTimeoutModal, deleteData, isAuthorised) => {
+export const initTimeout = (
+  showTimeoutModal,
+  deleteData,
+  isAuthorised,
+  isConfirmationPage = false
+) => {
   // TODO - isAuthorised to be replaced by caseType from pega
   // Fetches timeout length config
   settingTimer();
@@ -32,12 +37,12 @@ export const initTimeout = (showTimeoutModal, deleteData, isAuthorised) => {
     // TODO - unauth and sessiontimeout functionality to be implemented
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
-      if (isAuthorised) {
-        logout();
-      } else {
+      if (!isAuthorised && !isConfirmationPage) {
         deleteData();
         clearTimer();
         // session ends and deleteData() (pega)
+      } else {
+        logout();
       }
     }, milisecondsTilSignout);
   }, milisecondsTilWarning);
@@ -51,7 +56,7 @@ export function staySignedIn(
   isAuthorised = false,
   refreshSignin = true
 ) {
-  if (refreshSignin) {
+  if (refreshSignin && claimsListApi.length > 0) {
     // @ts-ignore
     PCore.getDataPageUtils().getDataAsync(claimsListApi, 'root');
   }

--- a/src/samples/StaticPages/ChooseClaimService/index.tsx
+++ b/src/samples/StaticPages/ChooseClaimService/index.tsx
@@ -17,8 +17,8 @@ export default function RecentlyClaimedChildBenefit() {
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
 
   useEffect(() => {
-    const setPageTitleInterval = setInterval(() => {
-      clearInterval(setPageTitleInterval);
+    const setPageTitleTimeout = setTimeout(() => {
+      clearInterval(setPageTitleTimeout);
       if (errorMsg.length > 0) {
         setPageTitle(true);
       } else {

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -469,28 +469,29 @@ export default function UnAuthChildBenefitsClaim() {
         {showDeletePage && <DeleteAnswers hasSessionTimedOut={hasSessionTimedOut} />}
         {bShowResolutionScreen && <ConfirmationPage caseId={caseId} isUnAuth />}
         {!showDeletePage && (
-        <TimeoutPopup
-          show={showTimeoutModal}
-          staySignedinHandler={() => {
-            if (bShowResolutionScreen) {
-              setShowTimeoutModal(false);
-              initTimeout(setShowTimeoutModal, deleteData, false, true);
-            } else {
-              staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false);
-            }
-          }}
-          signoutHandler={() => {
-            if (bShowResolutionScreen) {
-              logout();
-            } else {
-              deleteData();
-              clearTimer();
-              setHasSessionTimedOut(false);
-            }
-          }}
-          isAuthorised={false}
-          isConfirmationPage={bShowResolutionScreen}
-        />        
+          <TimeoutPopup
+            show={showTimeoutModal}
+            staySignedinHandler={() => {
+              if (bShowResolutionScreen) {
+                setShowTimeoutModal(false);
+                initTimeout(setShowTimeoutModal, deleteData, false, true);
+              } else {
+                staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false);
+              }
+            }}
+            signoutHandler={() => {
+              if (bShowResolutionScreen) {
+                logout();
+              } else {
+                deleteData();
+                clearTimer();
+                setHasSessionTimedOut(false);
+              }
+            }}
+            isAuthorised={false}
+            isConfirmationPage={bShowResolutionScreen}
+          />
+        )}
         {/** No Log out popup required as one isn't logged in */}
       </div>
 

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -52,7 +52,6 @@ export default function UnAuthChildBenefitsClaim() {
   // This needs to be changed in future when we handle the shutter for multiple service, for now this one's for single service
   const featureID = 'ChB';
   const featureType = 'Service';
-  const claimsListApi = '';
 
   const { t } = useTranslation();
 
@@ -114,9 +113,14 @@ export default function UnAuthChildBenefitsClaim() {
 
   // TODO - this function will have its pega counterpart for the feature to be completed - part of future story
   function deleteData() {
-    if (bShowPega) {
-      closeContainer();
+    const activeContainer = PCore.getContainerUtils().getActiveContainerItemContext('app/primary');
+    if (bShowPega && activeContainer) {
+      PCore.getContainerUtils().closeContainerItem(
+        PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+        { skipDirtyCheck: true }
+      );
     }
+
     setShowTimeoutModal(false);
     setShowStartPage(false);
     setShowPega(false);
@@ -125,7 +129,7 @@ export default function UnAuthChildBenefitsClaim() {
   }
 
   function returnToPortalPage() {
-    staySignedIn(setShowTimeoutModal, claimsListApi, false);
+    staySignedIn(setShowTimeoutModal, false);
     resetAppDisplay();
     setShowStartPage(true);
     closeContainer();
@@ -299,9 +303,7 @@ export default function UnAuthChildBenefitsClaim() {
       initTimeout(showTimeoutModal, deleteData, false);
 
       // Subscribe to any store change to reset timeout counter
-      PCore.getStore().subscribe(() =>
-        staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false, false)
-      );
+      PCore.getStore().subscribe(() => staySignedIn(setShowTimeoutModal, deleteData, false));
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
@@ -472,19 +474,15 @@ export default function UnAuthChildBenefitsClaim() {
           <TimeoutPopup
             show={showTimeoutModal}
             staySignedinHandler={() => {
-              if (bShowResolutionScreen) {
-                setShowTimeoutModal(false);
-                initTimeout(setShowTimeoutModal, deleteData, false, true);
-              } else {
-                staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false);
-              }
+              staySignedIn(setShowTimeoutModal, deleteData, false, bShowResolutionScreen);
             }}
             signoutHandler={() => {
               if (bShowResolutionScreen) {
                 logout();
               } else {
-                deleteData();
                 clearTimer();
+                deleteData();
+
                 setHasSessionTimedOut(false);
               }
             }}

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { render } from 'react-dom';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-
+import { logout } from '@pega/react-sdk-components/lib/components/helpers/authManager';
 import StoreContext from '@pega/react-sdk-components/lib/bridge/Context/StoreContext';
 import createPConnectComponent from '@pega/react-sdk-components/lib/bridge/react_pconnect';
 
@@ -417,6 +417,10 @@ export default function UnAuthChildBenefitsClaim() {
       fetchingIDsForHeader();
     });
 
+    document.addEventListener('SdkLoggedOut', () => {
+      window.location.href = 'https://www.gov.uk/government/organisations/hm-revenue-customs';
+    });
+
     // Subscriptions can't be done until onPCoreReady.
     // So we subscribe there. But unsubscribe when this
     // component is unmounted (in function returned from this effect)
@@ -470,9 +474,13 @@ export default function UnAuthChildBenefitsClaim() {
             staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false)
           }
           signoutHandler={() => {
-            deleteData();
-            clearTimer();
-            setHasSessionTimedOut(false);
+            if (bShowResolutionScreen) {
+              logout();
+            } else {
+              deleteData();
+              clearTimer();
+              setHasSessionTimedOut(false);
+            }
           }}
           isAuthorised={false}
           isConfirmationPage={bShowResolutionScreen}

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -52,7 +52,7 @@ export default function UnAuthChildBenefitsClaim() {
   // This needs to be changed in future when we handle the shutter for multiple service, for now this one's for single service
   const featureID = 'ChB';
   const featureType = 'Service';
-  const claimsListApi = 'D_GetUnauthClaimStatusBySessionID';
+  const claimsListApi = '';
 
   const { t } = useTranslation();
 
@@ -470,9 +470,14 @@ export default function UnAuthChildBenefitsClaim() {
         {bShowResolutionScreen && <ConfirmationPage caseId={caseId} isUnAuth />}
         <TimeoutPopup
           show={showTimeoutModal}
-          staySignedinHandler={() =>
-            staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false)
-          }
+          staySignedinHandler={() => {
+            if (bShowResolutionScreen) {
+              setShowTimeoutModal(false);
+              initTimeout(setShowTimeoutModal, deleteData, false, true);
+            } else {
+              staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false);
+            }
+          }}
           signoutHandler={() => {
             if (bShowResolutionScreen) {
               logout();

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -52,6 +52,7 @@ export default function UnAuthChildBenefitsClaim() {
   // This needs to be changed in future when we handle the shutter for multiple service, for now this one's for single service
   const featureID = 'ChB';
   const featureType = 'Service';
+  const claimsListApi = '';
 
   const { t } = useTranslation();
 
@@ -115,10 +116,7 @@ export default function UnAuthChildBenefitsClaim() {
   function deleteData() {
     const activeContainer = PCore.getContainerUtils().getActiveContainerItemContext('app/primary');
     if (bShowPega && activeContainer) {
-      PCore.getContainerUtils().closeContainerItem(
-        PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
-        { skipDirtyCheck: true }
-      );
+      PCore.getContainerUtils().closeContainerItem(activeContainer, { skipDirtyCheck: true });
     }
 
     setShowTimeoutModal(false);
@@ -129,7 +127,7 @@ export default function UnAuthChildBenefitsClaim() {
   }
 
   function returnToPortalPage() {
-    staySignedIn(setShowTimeoutModal, false);
+    staySignedIn(setShowTimeoutModal, claimsListApi, false);
     resetAppDisplay();
     setShowStartPage(true);
     closeContainer();
@@ -303,7 +301,9 @@ export default function UnAuthChildBenefitsClaim() {
       initTimeout(showTimeoutModal, deleteData, false);
 
       // Subscribe to any store change to reset timeout counter
-      PCore.getStore().subscribe(() => staySignedIn(setShowTimeoutModal, deleteData, false));
+      PCore.getStore().subscribe(() =>
+        staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false, false)
+      );
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
@@ -474,7 +474,14 @@ export default function UnAuthChildBenefitsClaim() {
           <TimeoutPopup
             show={showTimeoutModal}
             staySignedinHandler={() => {
-              staySignedIn(setShowTimeoutModal, deleteData, false, bShowResolutionScreen);
+              staySignedIn(
+                setShowTimeoutModal,
+                claimsListApi,
+                deleteData,
+                false,
+                false,
+                bShowResolutionScreen
+              );
             }}
             signoutHandler={() => {
               if (bShowResolutionScreen) {

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -475,6 +475,7 @@ export default function UnAuthChildBenefitsClaim() {
             setHasSessionTimedOut(false);
           }}
           isAuthorised={false}
+          isConfirmationPage={bShowResolutionScreen}
         />
 
         {/** No Log out popup required as one isn't logged in */}


### PR DESCRIPTION
These are the changes done according to the latest user story 12607 , where claimant will be having a timeout pop appearing on confirmation screen after submitting a claim.

Here claimant will be asked to either stay on same confirmation page or exit and go back to gov.uk page