### PR TITLE
fix: added status 'Resolved-Disallowance' to show CLAIM_RECEIVED

### DIFF
--- a/src/components/templates/ClaimsList/index.tsx
+++ b/src/components/templates/ClaimsList/index.tsx
@@ -26,6 +26,7 @@ export default function ClaimsList(props) {
       case 'Pending-SystemError':
       case 'Pending-AwaitingDocumentation':
       case 'Pending-Disallowance':
+      case 'Resolved-Disallowance':
         return { text: t('CLAIM_RECEIVED'), tagColour: 'purple' };
       default:
         return { text: status, tagColour: 'grey' };


### PR DESCRIPTION
Updated switch case for  'Resolved-Disallowance' to show CLAIM_RECEIVED status

![image](https://github.com/norm-l/odx/assets/154439730/215c1d6b-2c85-4b9e-be71-8d748e6cdc33)
