### PR TITLE
 screen functionality for HICBC claims

### DIFF
--- a/src/components/AppComponents/SummaryPage/SummaryPage.tsx
+++ b/src/components/AppComponents/SummaryPage/SummaryPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import  MainWrapper from '../../BaseComponents/MainWrapper' ;
+import ParsedHTML from '../../helpers/formatters/ParsedHtml';
+
+export default function SummaryPage(props){
+    const {summaryTitle, summaryContent, summaryBanner} = props;
+
+    if(summaryBanner && summaryBanner != ""){
+        return (<>
+                <MainWrapper>
+                    <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
+                        {summaryBanner}
+                    </div>
+                        <ParsedHTML htmlString={summaryContent} />
+                </MainWrapper>
+            </>
+        )
+    }
+    
+    return  <>
+        <MainWrapper>
+            <h1>
+                {summaryTitle}
+            </h1>
+            <ParsedHTML htmlString={summaryContent} />
+        </MainWrapper>
+    </>
+}

--- a/src/components/AppComponents/SummaryPage/index.tsx
+++ b/src/components/AppComponents/SummaryPage/index.tsx
@@ -1,0 +1,2 @@
+import SummaryPage from './SummaryPage';
+export default SummaryPage;

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -388,8 +388,8 @@ export default function Assignment(props) {
               />
             )}
             {(!isOnlyFieldDetails.isOnlyField ||
-              containerName.toLowerCase().includes('check your answer') ||
-              containerName.toLowerCase().includes('declaration')) && (
+              containerName?.toLowerCase().includes('check your answer') ||
+              containerName?.toLowerCase().includes('declaration')) && (
               <h1 className='govuk-heading-l'>
                 {localizedVal(containerName, '', localeReference)}
               </h1>

--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -8,7 +8,7 @@ import ShutterServicePage from '../../components/AppComponents/ShutterServicePag
 
 declare const PCore: any;
 
-const ConfirmationPage = ({ caseId, isUnAuth }) => {
+const ConfirmationPage = ({ caseId, caseStatus, isUnAuth }) => {
   const { t } = useTranslation();
   const [documentList, setDocumentList] = useState(``);
   const [isBornAbroadOrAdopted, setIsBornAbroadOrAdopted] = useState(false);
@@ -20,6 +20,7 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
   const docIDForDocList = 'CR0003';
   const docIDForReturnSlip = 'CR0002';
   const locale = PCore.getEnvironmentInfo().locale.replaceAll('-', '_');
+  const chbOfficeLink = 'https://www.gov.uk/child-benefit-tax-charge/your-circumstances-change';
 
   function getFeedBackLink() {
     return isUnAuth
@@ -31,43 +32,45 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
   }, []);
 
   useEffect(() => {
-    PCore.getDataPageUtils()
-      .getPageDataAsync('D_DocumentContent', 'root', {
-        DocumentID: docIDForDocList,
-        Locale: locale,
-        CaseID: caseId
-      })
-      .then(listData => {
-        if (
-          listData.DocumentContentHTML.includes("data-bornabroad='true'") ||
-          listData.DocumentContentHTML.includes("data-adopted='true'")
-        ) {
-          setIsBornAbroadOrAdopted(true);
-        }
-        setLoading(false);
-        setDocumentList(listData.DocumentContentHTML);
-        if (listData.DocumentContentHTML.includes('data-ninopresent="false"')) {
-          setIsCaseRefRequired(true);
-        }
-      })
-      .catch(err => {
-        // eslint-disable-next-line no-console
-        console.error(err);
-      });
+    if (caseStatus === undefined) {
+      PCore.getDataPageUtils()
+        .getPageDataAsync('D_DocumentContent', 'root', {
+          DocumentID: docIDForDocList,
+          Locale: locale,
+          CaseID: caseId
+        })
+        .then(listData => {
+          if (
+            listData.DocumentContentHTML.includes("data-bornabroad='true'") ||
+            listData.DocumentContentHTML.includes("data-adopted='true'")
+          ) {
+            setIsBornAbroadOrAdopted(true);
+          }
+          setLoading(false);
+          setDocumentList(listData.DocumentContentHTML);
+          if (listData.DocumentContentHTML.includes('data-ninopresent="false"')) {
+            setIsCaseRefRequired(true);
+          }
+        })
+        .catch(err => {
+          // eslint-disable-next-line no-console
+          console.error(err);
+        });
 
-    PCore.getDataPageUtils()
-      .getPageDataAsync('D_DocumentContent', 'root', {
-        DocumentID: docIDForReturnSlip,
-        Locale: locale,
-        CaseID: caseId
-      })
-      .then(pageData => {
-        setReturnSlipContent(pageData.DocumentContentHTML);
-      })
-      .catch(err => {
-        // eslint-disable-next-line no-console
-        console.error(err);
-      });
+      PCore.getDataPageUtils()
+        .getPageDataAsync('D_DocumentContent', 'root', {
+          DocumentID: docIDForReturnSlip,
+          Locale: locale,
+          CaseID: caseId
+        })
+        .then(pageData => {
+          setReturnSlipContent(pageData.DocumentContentHTML);
+        })
+        .catch(err => {
+          // eslint-disable-next-line no-console
+          console.error(err);
+        });
+    }
   }, []);
 
   const generateReturnSlip = e => {
@@ -76,85 +79,171 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
     myWindow.document.write(returnSlipContent);
   };
 
-  if (loading) {
+  const getBirthChildPanelContent = () => {
+    return (
+      <>
+        <h1 className='govuk-panel__title'> {t('APPLICATION_RECEIVED')}</h1>
+        {isUnAuth && isCaseRefRequired && (
+          <div className='govuk-panel__body'>
+            {t('YOUR_REF_NUMBER')}
+            <br></br>
+            <strong>{refId}</strong>
+          </div>
+        )}
+      </>
+    );
+  };
+
+  const getBirthChildBodyContent = () => {
+    return (
+      <>
+        <p className='govuk-body'> {t('WE_HAVE_SENT_YOUR_APPLICATION')}</p>
+        <h2 className='govuk-heading-m'> {t('WHAT_HAPPENS_NEXT')}</h2>
+        {isUnAuth && isCaseRefRequired && <p className='govuk-body'>{t('PRINT_THIS_INFO')}</p>}
+        <p className='govuk-body'> {t('WE_WILL_TELL_YOU_IN_14_DAYS')}</p>
+        <p className='govuk-body'>
+          <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
+            {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} {t('OPENS_IN_NEW_TAB')}
+          </a>
+        </p>
+      </>
+    );
+  };
+
+  const getAdoptedOrBornAbroadPanelContent = () => {
+    return (
+      <>
+        <h1 className='govuk-panel__title'>{t('APPLICATION_RECEIVED')}</h1>
+        {isUnAuth && isCaseRefRequired && (
+          <div className='govuk-panel__body govuk-!-margin-bottom-5'>
+            {t('YOUR_REF_NUMBER')}
+            <br></br>
+            <strong>{refId}</strong>
+          </div>
+        )}
+        <br />
+        <div className='govuk-panel__body govuk-!-font-size-27'>
+          {t('POST_YOUR_SUPPORTING_DOCUMENTS')}
+        </div>
+      </>
+    );
+  };
+
+  const getAdoptedOrBornAbroadBodyContent = () => {
+    return (
+      <>
+        <h2 className='govuk-heading-m'> {t('WHAT_YOU_NEED_TO_DO_NOW')} </h2>
+        {isUnAuth && isCaseRefRequired && <p className='govuk-body'>{t('PRINT_THIS_INFO')}</p>}
+        <p className='govuk-body'> {t('THE_INFO_YOU_HAVE_PROVIDED')}. </p>
+        <ParsedHTML htmlString={documentList} />
+        <p className='govuk-body'>
+          {t('AFTER_YOU_HAVE')}{' '}
+          <a href='' onClick={e => generateReturnSlip(e)} target='_blank' rel='noreferrer noopener'>
+            {t('PRINTED_AND_SIGNED_THE_FORM')} {t('OPENS_IN_NEW_TAB')}
+          </a>
+          , {t('RETURN_THE_FORM_WITH')}{' '}
+        </p>
+        <p className='govuk-body govuk-!-font-weight-bold'>
+          Child Benefit Office (GB)
+          <br />
+          Washington
+          <br />
+          NEWCASTLE UPON TYNE
+          <br />
+          NE88 1ZD
+        </p>
+        <p className='govuk-body'> {t('WE_NORMALLY_RETURN_DOCUMENTS_WITHIN')} </p>
+        <p className='govuk-body'>
+          <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
+            {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} {t('OPENS_IN_NEW_TAB')}
+          </a>
+        </p>
+      </>
+    );
+  };
+
+  const getHicbcPanelContent = () => {
+    return <h1 className='govuk-panel__title'>{caseStatus}</h1>;
+  };
+
+  const getHicbcBodyContent = () => {
+    return (
+      <>
+        <h2 className='govuk-heading-m'> {t('WHAT_HAPPENS_NEXT')}</h2>
+        <p className='govuk-body'>
+          You have now told us that you would like to be paid Child Benefit.
+        </p>
+        <p className='govuk-body'>We will pay Child Benefit to you from 7 April 2024.</p>
+        <p className='govuk-body'>
+          You will receive your payment within 28 days from your opt-in date.
+        </p>
+        <h2 className='govuk-heading-m'>If your circumstances change</h2>
+        <p className='govuk-body'>
+          You must{' '}
+          <a href={chbOfficeLink} className='govuk-link' target='_blank' rel='noreferrer'>
+            tell the Child Benefit office about changes in your family life that affect your
+            entitlement to Child Benefit.
+          </a>
+        </p>
+        <h2 className='govuk-heading-m'> Before you go</h2>
+        <p className='govuk-body'>Your feedback helps us make our service better.</p>
+        <p className='govuk-body'>
+          <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
+            Take our survey
+          </a>{' '}
+          to share your feedback on this service. It takes about 1 minute to complete.
+        </p>
+      </>
+    );
+  };
+
+  const setCasetype = () => {
+    if (caseStatus === undefined) {
+      if (!loading && isBornAbroadOrAdopted) {
+        return 'born-abroad';
+      } else {
+        return 'birthchild';
+      }
+    }
+    return 'hicbc';
+  };
+
+  const getPanelContent = () => {
+    switch (setCasetype()) {
+      case 'birthchild':
+        return getBirthChildPanelContent();
+      case 'born-abroad':
+        return getAdoptedOrBornAbroadPanelContent();
+      case 'hicbc':
+        return getHicbcPanelContent();
+      default:
+    }
+  };
+
+  const getBodyContent = () => {
+    switch (setCasetype()) {
+      case 'birthchild':
+        return getBirthChildBodyContent();
+      case 'born-abroad':
+        return getAdoptedOrBornAbroadBodyContent();
+      case 'hicbc':
+        return getHicbcBodyContent();
+      default:
+    }
+  };
+
+  if (loading && caseStatus === undefined) {
     return null;
   } else if (serviceShuttered) {
     return <ShutterServicePage />;
-  } else if (!loading && isBornAbroadOrAdopted) {
-    return (
-      <>
-        <MainWrapper>
-          <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
-            <h1 className='govuk-panel__title'> {t('APPLICATION_RECEIVED')}</h1>
-            {isUnAuth && isCaseRefRequired && (
-              <div className='govuk-panel__body govuk-!-margin-bottom-5'>
-                {t('YOUR_REF_NUMBER')}
-                <br></br>
-                <strong>{refId}</strong>
-              </div>
-            )}
-            <br />
-            <div className='govuk-panel__body govuk-!-font-size-27'>
-              {t('POST_YOUR_SUPPORTING_DOCUMENTS')}
-            </div>
-          </div>
-          <h2 className='govuk-heading-m'> {t('WHAT_YOU_NEED_TO_DO_NOW')} </h2>
-          {isUnAuth && isCaseRefRequired && <p className='govuk-body'>{t('PRINT_THIS_INFO')}</p>}
-          <p className='govuk-body'> {t('THE_INFO_YOU_HAVE_PROVIDED')}. </p>
-          <ParsedHTML htmlString={documentList} />
-          <p className='govuk-body'>
-            {t('AFTER_YOU_HAVE')}{' '}
-            <a
-              href=''
-              onClick={e => generateReturnSlip(e)}
-              target='_blank'
-              rel='noreferrer noopener'
-            >
-              {t('PRINTED_AND_SIGNED_THE_FORM')} {t('OPENS_IN_NEW_TAB')}
-            </a>
-            , {t('RETURN_THE_FORM_WITH')}{' '}
-          </p>
-          <p className='govuk-body govuk-!-font-weight-bold'>
-            Child Benefit Office (GB)
-            <br />
-            Washington
-            <br />
-            NEWCASTLE UPON TYNE
-            <br />
-            NE88 1ZD
-          </p>
-          <p className='govuk-body'> {t('WE_NORMALLY_RETURN_DOCUMENTS_WITHIN')} </p>
-          <p className='govuk-body'>
-            <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
-              {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} {t('OPENS_IN_NEW_TAB')}
-            </a>
-          </p>
-        </MainWrapper>
-      </>
-    );
   } else {
     return (
       <>
         <MainWrapper>
           <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
-            <h1 className='govuk-panel__title'> {t('APPLICATION_RECEIVED')}</h1>
-            {isUnAuth && isCaseRefRequired && (
-              <div className='govuk-panel__body'>
-                {t('YOUR_REF_NUMBER')}
-                <br></br>
-                <strong>{refId}</strong>
-              </div>
-            )}
+            {getPanelContent()}
           </div>
-          <p className='govuk-body'> {t('WE_HAVE_SENT_YOUR_APPLICATION')}</p>
-          <h2 className='govuk-heading-m'> {t('WHAT_HAPPENS_NEXT')}</h2>
-          {isUnAuth && isCaseRefRequired && <p className='govuk-body'>{t('PRINT_THIS_INFO')}</p>}
-          <p className='govuk-body'> {t('WE_WILL_TELL_YOU_IN_14_DAYS')}</p>
-          <p className='govuk-body'>
-            <a href={getFeedBackLink()} className='govuk-link' target='_blank' rel='noreferrer'>
-              {t('WHAT_DID_YOU_THINK_OF_THIS_SERVICE')} {t('OPENS_IN_NEW_TAB')}
-            </a>
-          </p>
+          {getBodyContent()}
         </MainWrapper>
       </>
     );

--- a/src/samples/HighIncomeCase/index.tsx
+++ b/src/samples/HighIncomeCase/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect} from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
@@ -11,106 +11,113 @@ import LogoutPopup from '../../components/AppComponents/LogoutPopup';
 import { logout } from '@pega/auth/lib/sdk-auth-manager';
 import { staySignedIn } from '../../components/AppComponents/TimeoutPopup/timeOutUtils';
 import { useStartMashup } from './reuseables/PegaSetup';
-import { initTimeout, settingTimer } from '../../components/AppComponents/TimeoutPopup/timeOutUtils';
 import {
-    loginIfNecessary, 
-  } from '@pega/react-sdk-components/lib/components/helpers/authManager';
-  
+  initTimeout,
+  settingTimer
+} from '../../components/AppComponents/TimeoutPopup/timeOutUtils';
+import { loginIfNecessary } from '@pega/react-sdk-components/lib/components/helpers/authManager';
+import ConfirmationPage from '../ChildBenefitsClaim/ConfirmationPage';
+
 // declare const myLoadMashup;
 
-const HighIncomeCase:FunctionComponent<any> = () => {
+const HighIncomeCase: FunctionComponent<any> = () => {
+  // const [bShowPega, setShowPega] = useState(false);
+  const [shutterServicePage /* setShutterServicePage */] = useState(false);
+  const [serviceNotAvailable /* setServiceNotAvailable */] = useState(false);
+  const [authType, setAuthType] = useState('gg');
 
-    // const [bShowPega, setShowPega] = useState(false);
-    const [shutterServicePage, /* setShutterServicePage */] = useState(false);
-    const [serviceNotAvailable, /* setServiceNotAvailable */] = useState(false);
-    const [authType, setAuthType] = useState('gg');
-    
-    const [showTimeoutModal, setShowTimeoutModal] = useState(false);  
-    const [showSignoutModal, setShowSignoutModal] = useState(false);
+  const [showTimeoutModal, setShowTimeoutModal] = useState(false);
+  const [showSignoutModal, setShowSignoutModal] = useState(false);
 
-    const history = useHistory();
-    useEffect(() => 
-        {initTimeout(setShowTimeoutModal, false, true) }  
-    , []);
+  const history = useHistory();
+  useEffect(() => {
+    initTimeout(setShowTimeoutModal, false, true);
+  }, []);
 
-    function doRedirectDone() {
-        history.push('/hicbc/opt-in');
-        // appName and mainRedirect params have to be same as earlier invocation
-        loginIfNecessary({ appName: 'embedded', mainRedirect: true });
-      } 
-    const { showPega, setShowPega } = useStartMashup(setAuthType, doRedirectDone);
+  function doRedirectDone() {
+    history.push('/hicbc/opt-in');
+    // appName and mainRedirect params have to be same as earlier invocation
+    loginIfNecessary({ appName: 'embedded', mainRedirect: true });
+  }
+  const { showPega, setShowPega, showResolutionPage, caseId, caseStatus } = useStartMashup(
+    setAuthType,
+    doRedirectDone
+  ); //
 
-    function signOut() {
-        //  const authService = authType === 'gg' ? 'GovGateway' : (authType === 'gg-dev' ? 'GovGateway-Dev' : authType);
-        let authService;
-        if (authType && authType === 'gg') {
-        authService = 'GovGateway';
-        } else if (authType && authType === 'gg-dev') {
-        authService = 'GovGateway-Dev';
-        }
-        const dpprom =PCore.getDataPageUtils()
-        .getPageDataAsync('D_AuthServiceLogout', 'root', { AuthService: authService }) as Promise<object>;
-        
-        dpprom.then(() => {
-            logout().then(() => {});
-        });
+  function signOut() {
+    //  const authService = authType === 'gg' ? 'GovGateway' : (authType === 'gg-dev' ? 'GovGateway-Dev' : authType);
+    let authService;
+    if (authType && authType === 'gg') {
+      authService = 'GovGateway';
+    } else if (authType && authType === 'gg-dev') {
+      authService = 'GovGateway-Dev';
     }
+    const dpprom = PCore.getDataPageUtils().getPageDataAsync('D_AuthServiceLogout', 'root', {
+      AuthService: authService
+    }) as Promise<object>;
 
-    function handleSignout() {
-        if (showPega) {
-        setShowSignoutModal(true);
-        } else {
-        signOut();
-        }
+    dpprom.then(() => {
+      logout().then(() => {});
+    });
+  }
+
+  function handleSignout() {
+    if (showPega) {
+      setShowSignoutModal(true);
+    } else {
+      signOut();
     }
+  }
 
-    const handleStaySignIn = e => {
-        e.preventDefault();
-        setShowSignoutModal(false);
-        // Extends manual signout popup 'stay signed in' to reset the automatic timeout timer also
-        staySignedIn(setShowTimeoutModal, null, null, null);
+  const handleStaySignIn = e => {
+    e.preventDefault();
+    setShowSignoutModal(false);
+    // Extends manual signout popup 'stay signed in' to reset the automatic timeout timer also
+    staySignedIn(setShowTimeoutModal, null, null, null);
+  };
+
+  const startClaim = () => {
+    setShowPega(true);
+    PCore.getMashupApi().createCase('HMRC-ChB-Work-HICBCPreference', PCore.getConstants().APP.APP);
+  };
+
+  /* ***
+   * Application specific PCore subscriptions
+   *
+   * TODO Can this be made into a tidy helper? including its own clean up? A custom hook perhaps
+   */
+  document.addEventListener('SdkConstellationReady', () => {
+    PCore.onPCoreReady(() => {
+      PCore.getPubSubUtils().subscribe(
+        PCore.getConstants().PUB_SUB_EVENTS.CONTAINER_EVENTS.CLOSE_CONTAINER_ITEM,
+        () => {
+          // console.log("SUBEVENT!!! showStartPageOnCloseContainerItem")
+          setShowPega(false);
+        },
+        'showStartPageOnCloseContainerItem'
+      );
+    });
+    settingTimer();
+  });
+
+  // And clean up
+
+  useEffect(() => {
+    return () => {
+      PCore.getPubSubUtils().unsubscribe(
+        PCore.getConstants().PUB_SUB_EVENTS.CONTAINER_EVENTS.CLOSE_CONTAINER_ITEM,
+        'showStartPageOnCloseContainerItem'
+      );
     };
+  }, []);
 
-    const startClaim= () => {
-        setShowPega(true);
-        PCore.getMashupApi().createCase('HMRC-ChB-Work-HICBCPreference', PCore.getConstants().APP.APP);           
-    }   
-
-
-
-    /* ***
-     * Application specific PCore subscriptions
-     * 
-     * TODO Can this be made into a tidy helper? including its own clean up? A custom hook perhaps 
-     */
-    document.addEventListener('SdkConstellationReady', () => {
-        PCore.onPCoreReady(() => {        
-        PCore.getPubSubUtils().subscribe(
-            PCore.getConstants().PUB_SUB_EVENTS.CONTAINER_EVENTS.CLOSE_CONTAINER_ITEM,
-            () => {
-                // console.log("SUBEVENT!!! showStartPageOnCloseContainerItem")
-                setShowPega(false);
-            },
-            'showStartPageOnCloseContainerItem'
-        );
-        })
-        settingTimer();
-    }); 
-    
-    // And clean up
-
-    useEffect(() => {
-        return () => {
-            PCore.getPubSubUtils().unsubscribe(PCore.getConstants().PUB_SUB_EVENTS.CONTAINER_EVENTS.CLOSE_CONTAINER_ITEM,'showStartPageOnCloseContainerItem')
-        }
-    }, [])
-
-
-    return (
+  return (
     <>
       <TimeoutPopup
         show={showTimeoutModal}
-        staySignedinHandler={() => staySignedIn(setShowTimeoutModal, 'D_ClaimantWorkAssignmentChBCases')}
+        staySignedinHandler={() =>
+          staySignedIn(setShowTimeoutModal, 'D_ClaimantWorkAssignmentChBCases')
+        }
         signoutHandler={() => logout()}
         isAuthorised
       />
@@ -120,10 +127,12 @@ const HighIncomeCase:FunctionComponent<any> = () => {
         appname={useTranslation().t('HIGH_INCOME_BENEFITS')}
         hasLanguageToggle
         isPegaApp={showPega}
-        languageToggleCallback={() => {}/* toggleNotificationProcess(
+        languageToggleCallback={
+          () => {} /* toggleNotificationProcess(
           { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
           assignmentPConn 
-        ) */}
+        ) */
+        }
       />
       <div className='govuk-width-container'>
         {shutterServicePage ? (
@@ -136,11 +145,13 @@ const HighIncomeCase:FunctionComponent<any> = () => {
 
             {serviceNotAvailable && <ServiceNotAvailable />}
 
-            { !showPega && <StartPage onStart={startClaim}/>}
+            {!showPega && <StartPage onStart={startClaim} />}
 
-            </>
+            {showResolutionPage && (
+              <ConfirmationPage caseStatus={caseStatus} caseId={caseId} isUnAuth={false} />
+            )}
+          </>
         )}
-
       </div>
 
       <LogoutPopup
@@ -151,8 +162,7 @@ const HighIncomeCase:FunctionComponent<any> = () => {
       />
       <AppFooter />
     </>
-    )
-}
+  );
+};
 
-
-export default HighIncomeCase ;
+export default HighIncomeCase;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,7 +108,7 @@ module.exports = (env, argv) => {
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // both options are optional
-      filename: '/assets/appStyles.css'
+      filename: 'assets/appStyles.css'
     })
   );
 


### PR DESCRIPTION
Creates new 'Summary' Component to handle both confirmation and other 'end' screens for journeys.
This component will take a summary content block, which is parsed if html, a title and banner text.
If the component received banner text, it will display this in the green confirmation banner, followed by the content block,
otherwise it will display the title as plain h1, followed by the content block..

Also adds functionality to store the Case ID before closing a case, to allow fetching of summary page content on loading of the 'End page'