### PR TITLE
Bug - 8114 : Should not render the timeout modal once claimant encounter the delete answers screen

### DIFF
--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -464,19 +464,20 @@ export default function UnAuthChildBenefitsClaim() {
         {serviceNotAvailable && <ServiceNotAvailable returnToPortalPage={returnToPortalPage} />}
         {showDeletePage && <DeleteAnswers hasSessionTimedOut={hasSessionTimedOut} />}
         {bShowResolutionScreen && <ConfirmationPage caseId={caseId} isUnAuth />}
-        <TimeoutPopup
-          show={showTimeoutModal}
-          staySignedinHandler={() =>
-            staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false)
-          }
-          signoutHandler={() => {
-            deleteData();
-            clearTimer();
-            setHasSessionTimedOut(false);
-          }}
-          isAuthorised={false}
-        />
-
+        {!showDeletePage && (
+          <TimeoutPopup
+            show={showTimeoutModal}
+            staySignedinHandler={() =>
+              staySignedIn(setShowTimeoutModal, claimsListApi, deleteData, false)
+            }
+            signoutHandler={() => {
+              deleteData();
+              clearTimer();
+              setHasSessionTimedOut(false);
+            }}
+            isAuthorised={false}
+          />
+        )}
         {/** No Log out popup required as one isn't logged in */}
       </div>
 


### PR DESCRIPTION
Once the claim has been deleted , the claimant should not see the timeout pop up.

so , as a current fix , we are conditionally rendering the pop up.