### PR TITLE
Bug-8166 : Welsh translation for static page error messages

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -125,11 +125,11 @@
   "COOKIE_AWSALB_DESCRIPTION": "Defnyddir hyn i helpu i reoli’r traffig rhwng porwr gwe ymwelwr a gweinydd y rhaglen sy’n cynnal gwasanaethau CThEF.",
   "COOKIE_AWSALBCORS_DESCRIPTION": "Defnyddir hyn i helpu i reoli’r traffig rhwng porwr gwe ymwelwr a gweinydd y rhaglen sy’n cynnal gwasanaethau CThEF.",
   "COOKIE_JSESSIONID_DESCRIPTION": "Defnyddir hyn i adnabod gwybodaeth am sesiwn yr ymwelwr, a’r wybodaeth honno yn ymwneud â’r gwasanaeth sy’n cael ei ddefnyddio.",
-  
+
   "COOKIE_PEGAODXEI_DESCRIPTION": "This is used to identify the session ID of a user not using Government Gateway.",
   "COOKIE_PEGAODXDI_DESCRIPTION": "This is used to uniquely identify a device that has interacted with HMRC services and is used for internal security auditing.",
   "COOKIE_AKA_A2_DESCRIPTION": "This Akamai cookie is used to help speed up content delivery on websites using adaptive acceleration.",
-  
+
   "COOKIE_FIND_OUT_MORE": "Dysgwch ragor am gwcis ar wasanaethau CThEF",
   "GDS_INFO_IMPORTANT": "Pwysig",
   "GDS_INFO_SUCCESS": "Llwyddiant",
@@ -229,7 +229,7 @@
   "COMPLETE_THE_CHB_APPLICATION_FORM_QUICKLY": "llenwi’r ffurflen gais ar gyfer Budd-dal Plant yn gyflym",
   "RECEIVE_TEXT_MESSAGE_UPDATES": "cael diweddariadau drwy neges destun",
   "DO_YOU_WANT_TO_SIGN_IN": "A ydych am fewngofnodi?",
-  "SELECT_YES_IF_YOU_WANT_TO_SIGN_IN": "Select yes if you want to sign in",
+  "SELECT_YES_IF_YOU_WANT_TO_SIGN_IN": "Dewiswch ‘Iawn’ os ydych am fewngofnodi",
   "MAKE_A_NEW_CLAIM": "Gwneud hawliad newydd",
   "ADD_CHILD_TO_EXISTING_CLAIM": "Ychwanegu plentyn at hawliad sy’n bodoli eisoes",
   "CHECK_PROGRESS_OF_CLAIM": "Gweld hynt hawliad",
@@ -242,5 +242,6 @@
   "CHECK_CLAIM_REPLY": "wirio pryd y gallwch ddisgwyl ymateb i’ch hawliad (yn agor tab newydd).",
   "CHECK_CLAIM_APPROVED": "I wirio os yw’ch hawliad am Fudd-dal Plant wedi’i gymeradwyo, gallwch fwrw golwg dros eich tystiolaeth o hawl. ",
   "YOU_NEED_TO_SIGN_IN_TO_ACCESS_INFO": "Bydd angen i chi mewngofnodi i gael at yr wybodaeth hon. Os nad oes gennych fanylion mewngofnodi, gallwch eu creu (yn agor tab newydd).",
-  "EXCLUSIVEOPTION_OR": "neu"
+  "EXCLUSIVEOPTION_OR": "neu",
+  "SELECT_CHILD_BENEFIT_SERVICE": "Dewiswch pa wasanaeth Budd-dal Plant yr hoffech ei ddefnyddio"
 }

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -125,7 +125,7 @@
   "COOKIE_AWSALB_DESCRIPTION": "Used to help manage web traffic between a visitors web browser and the application servers that host HMRC services.",
   "COOKIE_AWSALBCORS_DESCRIPTION": "Used to help manage web traffic between a visitors web browser and the application servers that host HMRC services.",
   "COOKIE_JSESSIONID_DESCRIPTION": "Used to identify the visitor’s session information related to the HMRC service being accessed.",
-  
+
   "COOKIE_PEGAODXEI_DESCRIPTION": "This is used to identify the session ID of a user not using Government Gateway.",
   "COOKIE_PEGAODXDI_DESCRIPTION": "This is used to uniquely identify a device that has interacted with HMRC services and is used for internal security auditing.",
   "COOKIE_AKA_A2_DESCRIPTION": "This Akamai cookie is used to help speed up content delivery on websites using adaptive acceleration.",
@@ -242,5 +242,6 @@
   "CHECK_CLAIM_REPLY": "check when you can expect a reply to your claim (opens in new tab).",
   "CHECK_CLAIM_APPROVED": "To check if your claim for Child Benefit has been approved, you can view your proof of entitlement. ",
   "YOU_NEED_TO_SIGN_IN_TO_ACCESS_INFO": "You will need to sign in to access this information. If you do not have sign in details, you can create them (opens in new tab).",
-  "EXCLUSIVEOPTION_OR": "or"
+  "EXCLUSIVEOPTION_OR": "or",
+  "SELECT_CHILD_BENEFIT_SERVICE": "Select which Child Benefit service you would like to use"
 }

--- a/src/samples/StaticPages/ChooseClaimService/index.tsx
+++ b/src/samples/StaticPages/ChooseClaimService/index.tsx
@@ -76,7 +76,7 @@ export default function RecentlyClaimedChildBenefit() {
           break;
       }
     } else {
-      setErrorMsg(t('CONFIRM_YOUR_SERVICE'));
+      setErrorMsg(t('SELECT_CHILD_BENEFIT_SERVICE'));
     }
   }
   return (


### PR DESCRIPTION
As a part of this Bug , we are adding missing welsh translations required for error messages on choose claim service and do you want to sign in pages.