### PR TITLE
revised check answers screen

### DIFF
--- a/sdk-local-component-map.js
+++ b/sdk-local-component-map.js
@@ -27,6 +27,7 @@ import HmrcOdxGdsTaskList from './src/components/custom-sdk/widget/HMRC_ODX_GDST
 import HmrcOdxGdsTaskListTemplate from './src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/';
 import AutoComplete from './src/components/override-sdk/field/AutoComplete/';
 import HmrcOdxGdsTextPresentation from './src/components/custom-sdk/field/HMRC_ODX_GDSTextPresentation/';
+import HmrcOdxGdsCheckAnswersScreen from './src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/';
 /*import end - DO NOT REMOVE*/
 
 // localSdkComponentMap is the JSON object where we'll store the components that are
@@ -59,7 +60,8 @@ const localSdkComponentMap = {
   HMRC_ODX_ComplexQuestionExplanation: HmrcOdxComplexQuestionExplanation,
   AutoComplete: AutoComplete,
   HMRC_ODX_GDSTextPresentation: HmrcOdxGdsTextPresentation,
-  HMRC_ODX_GDSTaskListTemplate: HmrcOdxGdsTaskListTemplate
+  HMRC_ODX_GDSTaskListTemplate: HmrcOdxGdsTaskListTemplate,
+  HMRC_ODX_GDSCheckAnswersScreen: HmrcOdxGdsCheckAnswersScreen
   /*map end - DO NOT REMOVE*/
 };
 

--- a/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/demo.stories.jsx
+++ b/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/demo.stories.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import { stateProps, configProps } from './mock.stories';
+
+import HmrcOdxGdsCheckAnswersScreen from './index.jsx';
+
+export default {
+  title: 'HmrcOdxGdsCheckAnswersScreen',
+  decorators: [withKnobs],
+  component: HmrcOdxGdsCheckAnswersScreen
+};
+
+export const baseHmrcOdxGdsCheckAnswersScreen = () => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [value, setValue] = useState(configProps.value);
+
+  const props = {
+    value,
+    placeholder: configProps.placeholder,
+    label: configProps.label,
+    testId: configProps.testId,
+    hasSuggestions: configProps.hasSuggestions,
+
+    getPConnect: () => {
+      return {
+        getStateProps: () => {
+          return stateProps;
+        },
+        getActionsApi: () => {
+          return {
+            updateFieldValue: (propName, theValue) => {
+              setValue(theValue);
+            },
+            triggerFieldChange: () => {/* nothing */}
+          };
+        },
+        ignoreSuggestion: () => {/* nothing */},
+        acceptSuggestion: () => {/* nothing */},
+        setInheritedProps: () => {/* nothing */},
+        resolveConfigProps: () => {/* nothing */}
+      };
+    }
+  };
+
+  return (
+    <>
+      <HmrcOdxGdsCheckAnswersScreen {...props} />
+    </>
+  );
+};

--- a/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/index.jsx
+++ b/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/index.jsx
@@ -1,0 +1,61 @@
+import PropTypes from 'prop-types';
+import { Input } from '@pega/cosmos-react-core';
+
+import StyledHmrcOdxGdsCheckAnswersScreenWrapper from './styles';
+
+
+// Duplicated runtime code from Constellation Design System Component
+
+// props passed in combination of props from property panel (config.json) and run time props from Constellation
+// any default values in config.pros should be set in defaultProps at bottom of this file
+const HmrcOdxGdsCheckAnswersScreen = props => {
+  const { getPConnect, value, placeholder, disabled, readOnly, required, label, hideLabel, testId } = props;
+
+  const pConn = getPConnect();
+  const actions = pConn.getActionsApi();
+  const propName = pConn?.getStateProps()?.value;
+
+  const handleOnChange = event => {
+    const { value: updatedValue } = event.target;
+    actions.updateFieldValue(propName, updatedValue);
+  };
+
+  return (
+    <StyledHmrcOdxGdsCheckAnswersScreenWrapper>
+      <Input
+        type='text'
+        value={value}
+        label={label}
+        labelHidden={hideLabel}
+        placeholder={placeholder}
+        disabled={disabled}
+        readOnly={readOnly}
+        required={required}
+        onChange={handleOnChange}
+        testId={testId}
+      />
+    </StyledHmrcOdxGdsCheckAnswersScreenWrapper>
+  );
+};
+
+HmrcOdxGdsCheckAnswersScreen.defaultProps = {
+  value: '',
+  placeholder: '',
+  disabled: false,
+  readOnly: false,
+  required: false,
+  testId: ''
+};
+
+HmrcOdxGdsCheckAnswersScreen.propTypes = {
+  label: PropTypes.string,
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  getPConnect: PropTypes.func.isRequired,
+  disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  readOnly: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  required: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  testId: PropTypes.string
+};
+
+export default HmrcOdxGdsCheckAnswersScreen;

--- a/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/mock.stories.js
+++ b/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/mock.stories.js
@@ -1,0 +1,13 @@
+export const configProps = {
+  value: '',
+  label: 'Text Sample',
+  placeholder: 'Text Placeholder',
+  helperText: 'Text Helper Text',
+  testId: 'Text-12345678',
+  hasSuggestions: false
+};
+
+export const stateProps = {
+  value: '.TextSample',
+  hasSuggestions: false
+};

--- a/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/styles.js
+++ b/src/components/custom-constellation/field/HMRC_ODX_GDSCheckAnswersScreen/styles.js
@@ -1,0 +1,14 @@
+// utilizing theming, comment out, if want individual style
+import styled from 'styled-components';
+import { Configuration } from '@pega/cosmos-react-core';
+
+export default styled(Configuration)``;
+
+// individual style, comment out above, and uncomment here and add styles
+// import styled, { css } from 'styled-components';
+//
+// export default styled.div(() => {
+//  return css`
+//    margin: 0px 0;
+//  `;
+// });

--- a/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/config.json
+++ b/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/config.json
@@ -1,0 +1,89 @@
+{
+  "name": "HMRC_ODX_GDSCheckAnswersScreen",
+  "label": "GDSCheckAnswersScreen",
+  "description": "GDSCheckAnswersScreen",
+  "organization": "HMRC",
+  "version": "0.0.1",
+  "library": "ODX",
+  "allowedApplications": [],
+  "componentKey": "HMRC_ODX_GDSCheckAnswersScreen",
+  "type": "Field",
+  "subtype": "Text",
+  "icon": "images/pz-url-active.svg",
+  "properties": [
+    {
+      "name": "label",
+      "label": "Field label",
+      "format": "TEXT",
+      "required": true
+    },
+    {
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "format": "TEXT",
+      "required": false
+    },
+    {
+      "name": "readOnly",
+      "label": "Edit mode",
+      "format": "READONLY"
+    },
+    {
+      "label": "Input settings",
+      "format": "GROUP",
+      "visibility": "(!readOnly = true)",
+      "properties": [
+        {
+          "name": "placeholder",
+          "label": "Placeholder",
+          "format": "TEXT"
+        },
+        {
+          "name": "helperText",
+          "label": "Helper text",
+          "format": "TEXT"
+        }
+      ]
+    },
+    {
+      "label": "Conditions",
+      "format": "GROUP",
+      "properties": [
+        {
+          "name": "required",
+          "label": "Required",
+          "format": "REQUIRED",
+          "visibility": "(!readOnly = true)"
+        },
+        {
+          "name": "disabled",
+          "label": "Disabled",
+          "format": "DISABLED",
+          "visibility": "(!readOnly = true)"
+        },
+        {
+          "name": "visibility",
+          "label": "Visibility",
+          "format": "VISIBILITY"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "format": "GROUP",
+      "collapsible": true,
+      "properties": [
+        {
+          "name": "testId",
+          "label": "Test ID",
+          "format": "TEXT",
+          "ignorePattern": "[^-_\\p{N}\\p{L}]",
+          "includeAnnotations": false
+        }
+      ]
+    }
+  ],
+  "defaultConfig": {
+    "label": "@L $this.label"
+  }
+}

--- a/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/demo.stories.jsx
+++ b/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/demo.stories.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import HmrcOdxGdsCheckAnswersScreen from './index.tsx';
+import { withKnobs } from '@storybook/addon-knobs';
+import { configProps } from './mock.stories';
+
+export default {
+  title: 'HmrcOdxGdsCheckAnswersScreen',
+  decorators: [withKnobs],
+  component: HmrcOdxGdsCheckAnswersScreen
+};
+
+export const BaseHmrcOdxGdsCheckAnswersScreen = () => {
+  const [value, setValue] = useState(configProps.value);
+
+  const props = {
+    value,
+    placeholder: configProps.placeholder,
+    label: configProps.label,
+    testId: configProps.testId,
+    hasSuggestions: configProps.hasSuggestions,
+    helperText: configProps.helperText,
+    disabled: configProps.disabled,
+    required: configProps.required,
+    readOnly: configProps.readOnly,
+    displayMode: configProps.displayMode,
+    getPConnect: () => {
+      return {
+        getActionsApi: () => {
+          return {
+            updateFieldValue: (propName, theValue) => {
+              setValue(theValue);
+            }
+          };
+        },
+        getStateProps: () => {
+          return { value: '.name' };
+        }
+      };
+    },
+    onChange: (event) => { setValue(event.target.value); },
+    onBlur: () => { return configProps.value; }
+  };
+
+  return (
+    <>
+      <HmrcOdxGdsCheckAnswersScreen {...props} />
+    </>
+  );
+};

--- a/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/index.tsx
+++ b/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/index.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import type { PConnFieldProps } from '@pega/react-sdk-components/lib/types/PConnProps';
+
+interface HmrcOdxTestProps extends PConnFieldProps {
+  // If any, enter additional props that only exist on this componentName
+  name?: string;
+  stepId?: any;
+}
+
+// Duplicated runtime code from React SDK
+
+// props passed in combination of props from property panel (config.json) and run time props from Constellation
+// any default values in config.pros should be set in defaultProps at bottom of this file
+export default function GDSCheckAnswers(props: HmrcOdxTestProps) {
+  const COMMA_DELIMITED_FIELD = 'CSV';
+  const { label, value, name, stepId, getPConnect } = props;
+  const [formattedValue, setFormattedValue] = useState<string | Array<string>>(value);
+  const pConn = getPConnect();
+  const actions = pConn.getActionsApi();
+  const containerItemID = pConn.getContextName();
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/prefer-includes
+    if (name && name.indexOf(COMMA_DELIMITED_FIELD) !== -1 && value.indexOf(',') !== -1) {
+      const formatValue = value.split(',').map((item: string) => item.trim());
+      setFormattedValue(formatValue);
+    }
+  }, []);
+  const handleOnClick = () => {
+    const navigateToStepPromise = actions.navigateToStep(stepId, containerItemID);
+
+    navigateToStepPromise
+      .then(() => {
+        //  navigate to step success handling
+        console.log('navigation successful'); // eslint-disable-line
+      })
+      .catch(error => {
+        // navigate to step failure handling
+        // eslint-disable-next-line no-console
+        console.log('Change link Navigation failed', error);
+      });
+  };
+
+  return (
+    <div className='govuk-summary-list__row'>
+      <dt className='govuk-summary-list__key'>{label}</dt>
+
+      <dd className='govuk-summary-list__value'>
+        {Array.isArray(formattedValue) ? (
+          <ul className='govuk-list'>
+            {formattedValue.map(valueItem => (
+              <li key={valueItem}>{valueItem}</li>
+            ))}
+          </ul>
+        ) : (
+          formattedValue || value
+        )}{' '}
+      </dd>
+      <dd>
+        {/* <div className='govuk-!-margin-bottom-9' style={{ display: 'flex', gap: '20px' }}>
+          <span style={{ marginLeft: 'auto' }}> */}
+        <a href='#' className='govuk-link' onClick={handleOnClick}>
+          Change<span className='govuk-visually-hidden'> {label}</span>
+        </a>
+        {/* </span>
+        </div> */}
+      </dd>
+    </div>
+  );
+}

--- a/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/mock.stories.js
+++ b/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/mock.stories.js
@@ -1,0 +1,13 @@
+// eslint-disable-next-line import/prefer-default-export
+export const configProps = {
+  value: '',
+  label: 'Text Sample',
+  placeholder: 'Text Placeholder',
+  helperText: 'Text Helper Text',
+  testId: 'Text-12345678',
+  hasSuggestions: false,
+  disabled: false,
+  readOnly: false,
+  required: false,
+  displayMode: ''
+};

--- a/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/styles.js
+++ b/src/components/custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/styles.js
@@ -1,0 +1,7 @@
+import styled, { css } from 'styled-components';
+
+export default styled.div(() => {
+  return css`
+    margin: 0px 0;
+  `;
+});

--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import GDSAutocomplete from '../../../BaseComponents/Autocomplete/Autocomplete';
 import Utils from '@pega/react-sdk-components/lib/components/helpers/utils';
 import isDeepEqual from 'fast-deep-equal/react';
@@ -8,6 +8,8 @@ import FieldValueList from '@pega/react-sdk-components/lib/components/designSyst
 import type { PConnFieldProps } from '@pega/react-sdk-components/lib/types/PConnProps';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/index';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 interface IOption {
   key: string;
@@ -52,6 +54,7 @@ interface AutoCompleteProps extends PConnFieldProps {
   displayOrder: string;
   hideLabel: boolean;
   name: string;
+  configAlternateDesignSystem: any;
 }
 
 export default function AutoComplete(props: AutoCompleteProps) {
@@ -68,8 +71,10 @@ export default function AutoComplete(props: AutoCompleteProps) {
     helperText,
     hideLabel,
     displayOrder,
+    configAlternateDesignSystem,
     name
   } = props;
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
   const [errorMessage, setErrorMessage] = useState(validatemessage);
   const [isAutocompleteLoaded, setAutocompleteLoaded] = useState(false);
   const context = getPConnect().getContextName();
@@ -211,6 +216,26 @@ export default function AutoComplete(props: AutoCompleteProps) {
 
   if (displayMode === 'STACKED_LARGE_VAL') {
     return <FieldValueList name={hideLabel ? '' : label} value={value} variant='stacked' />;
+  }
+
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
   }
 
   if (readOnly) {

--- a/src/components/override-sdk/field/AutoComplete/config-ext.json
+++ b/src/components/override-sdk/field/AutoComplete/config-ext.json
@@ -4,8 +4,20 @@
   "description": "Picklist",
   "type": "Field",
   "subtype": "Picklist",
-  "componentKey" : "AutoComplete",
+  "componentKey": "AutoComplete",
   "icon": "",
   "properties": [
+    {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    }
   ]
 }

--- a/src/components/override-sdk/field/Checkbox/Checkbox.tsx
+++ b/src/components/override-sdk/field/Checkbox/Checkbox.tsx
@@ -6,11 +6,21 @@ import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDis
 import { DefaultFormContext, ErrorMsgContext } from '../../../helpers/HMRCAppContext';
 import { checkErrorMsgs, removeRedundantString } from '../../../helpers/utils';
 import { t } from 'i18next';
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 export default function CheckboxComponent(props) {
   const { OverrideLabelValue } = useContext(DefaultFormContext);
 
-  const { getPConnect, inputProps, validatemessage, hintText, readOnly, value } = props;
+  const {
+    getPConnect,
+    inputProps,
+    validatemessage,
+    hintText,
+    readOnly,
+    value,
+    configAlternateDesignSystem
+  } = props;
 
   // let label = props.label;
 
@@ -29,7 +39,7 @@ export default function CheckboxComponent(props) {
   /* retaining for future reference, incase changes need to be reverted
  
   if(isOnlyField && !readOnly) label = overrideLabel.trim() ? overrideLabel : label; */
-
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
   const [errorMessage, setErrorMessage] = useState(validatemessage);
   const { errorMsgs } = useContext(ErrorMsgContext);
 
@@ -52,6 +62,25 @@ export default function CheckboxComponent(props) {
   const { caption } = theConfigProps;
   const actionsApi = thePConn.getActionsApi();
   const propName = thePConn.getStateProps().value;
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
+  }
 
   if (readOnly) {
     return <ReadOnlyDisplay value={value ? props.trueLabel : props.falseLabel} label={caption} />;
@@ -72,7 +101,8 @@ export default function CheckboxComponent(props) {
         <div className={`govuk-form-group ${errorMessage ? 'govuk-form-group--error' : ''}`}>
           {errorMessage && (
             <p id={`${name}-error`} className='govuk-error-message'>
-              <span className='govuk-visually-hidden'>Error:</span> {removeRedundantString(errorMessage)}
+              <span className='govuk-visually-hidden'>Error:</span>{' '}
+              {removeRedundantString(errorMessage)}
             </p>
           )}
           <GDSCheckbox

--- a/src/components/override-sdk/field/Checkbox/config-ext.json
+++ b/src/components/override-sdk/field/Checkbox/config-ext.json
@@ -4,7 +4,19 @@
   "description": "Boolean",
   "type": "Field",
   "subtype": "Boolean",
-  "componentKey" : "Checkbox",
+  "componentKey": "Checkbox",
   "properties": [
+    {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    }
   ]
 }

--- a/src/components/override-sdk/field/Date/Date.tsx
+++ b/src/components/override-sdk/field/Date/Date.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect, useEffect } from 'react';
+import React, { useState, useLayoutEffect, useEffect, useContext } from 'react';
 import DateInput from '../../../BaseComponents/DateInput/DateInput';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
@@ -8,6 +8,8 @@ import {
 } from '../../../helpers/formatters/DateErrorFormatter';
 import { GBdate } from '../../../helpers/utils';
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen/index';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 declare const global;
 
@@ -39,8 +41,10 @@ export default function Date(props) {
     )
   );
   const [specificErrors, setSpecificErrors] = useState<any>(null);
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
 
   const actionsApi = getPConnect().getActionsApi();
+
   const propName = getPConnect().getStateProps().value;
   // PM - Create ISODate string (as expected by onChange) and pass to onchange value, adding 0 padding here for day and month to comply with isostring format.
   const handleDateChange = () => {
@@ -113,6 +117,25 @@ export default function Date(props) {
     return <span className='govuk-body govuk-!-font-weight-bold'>{GBdate(value)}</span>;
   }
 
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
+  }
   if (readOnly) {
     return <ReadOnlyDisplay label={label} value={new global.Date(value).toLocaleDateString()} />;
   }

--- a/src/components/override-sdk/field/Date/config-ext.json
+++ b/src/components/override-sdk/field/Date/config-ext.json
@@ -4,8 +4,20 @@
   "description": "Date only",
   "type": "Field",
   "subtype": "Date",
-  "componentKey" : "Date",
+  "componentKey": "Date",
   "properties": [
+    {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    },
     {
       "format": "SELECT",
       "name": "autocomplete",

--- a/src/components/override-sdk/field/Dropdown/Dropdown.tsx
+++ b/src/components/override-sdk/field/Dropdown/Dropdown.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import Utils from '@pega/react-sdk-components/lib/components/helpers/utils';
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 import Select from '../../../BaseComponents/Select/Select';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 interface IOption {
   key: string;
@@ -21,8 +23,10 @@ export default function Dropdown(props) {
     helperText,
     readOnly,
     name,
-    fieldMetadata
+    fieldMetadata,
+    configAlternateDesignSystem
   } = props;
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
 
   const [options, setOptions] = useState<Array<IOption>>([]);
   const [displayValue, setDisplayValue] = useState();
@@ -74,7 +78,25 @@ export default function Dropdown(props) {
     const selectedValue = evt.target.value === placeholder ? '' : evt.target.value;
     handleEvent(actionsApi, 'changeNblur', propName, selectedValue);
   };
-
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
+  }
   if (readOnly) {
     return (
       <ReadOnlyDisplay

--- a/src/components/override-sdk/field/Dropdown/config-ext.json
+++ b/src/components/override-sdk/field/Dropdown/config-ext.json
@@ -1,9 +1,22 @@
 {
-    "componentKey": "Dropdown",
-    "name": "Dropdown",
-    "label": "Dropdown",
-    "description": "Picklist",
-    "type": "Field",
-    "subtype": "Picklist",
-    "properties": []
+  "componentKey": "Dropdown",
+  "name": "Dropdown",
+  "label": "Dropdown",
+  "description": "Picklist",
+  "type": "Field",
+  "subtype": "Picklist",
+  "properties": [
+    {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    }
+  ]
 }

--- a/src/components/override-sdk/field/RadioButtons/RadioButtons.tsx
+++ b/src/components/override-sdk/field/RadioButtons/RadioButtons.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import GDSRadioButtons from '../../../BaseComponents/RadioButtons/RadioButtons';
-import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks'
+import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import Utils from '@pega/react-sdk-components/lib/components/helpers/utils';
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
-
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 export default function RadioButtons(props) {
   const {
@@ -15,20 +16,20 @@ export default function RadioButtons(props) {
     readOnly,
     value,
     name,
-    
+    configAlternateDesignSystem,
     testId,
     fieldMetadata
   } = props;
-
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
   let label = props.label;
-  const {isOnlyField, overrideLabel} = useIsOnlyField(props.displayOrder);
-  if(isOnlyField && !readOnly) label = overrideLabel.trim() ? overrideLabel : label;
+  const { isOnlyField, overrideLabel } = useIsOnlyField(props.displayOrder);
+  if (isOnlyField && !readOnly) label = overrideLabel.trim() ? overrideLabel : label;
 
-  const[errorMessage,setErrorMessage] = useState(validatemessage);
-  useEffect(()=>{
-    setErrorMessage(validatemessage)
-  },[validatemessage])
- 
+  const [errorMessage, setErrorMessage] = useState(validatemessage);
+  useEffect(() => {
+    setErrorMessage(validatemessage);
+  }, [validatemessage]);
+
   const thePConn = getPConnect();
   const theConfigProps = thePConn.getConfigProps();
   const className = thePConn.getCaseInfo().getClassName();
@@ -51,22 +52,43 @@ export default function RadioButtons(props) {
   const localeName = localeContext === 'datapage' ? metaData?.datasource?.name : configProperty;
   const localePath = localeContext === 'datapage' ? displayName : localeName;
 
-
-
   let displayValue = null;
-  if(selectedOption && selectedOption.value){
+  if (selectedOption && selectedOption.value) {
     displayValue = selectedOption.value;
   }
-
-  if(readOnly){
-    return <ReadOnlyDisplay label={label} value={thePConn.getLocalizedValue(
-      displayValue,
-      localePath,
-      thePConn.getLocaleRuleNameFromKeys(localeClass, localeContext, localeName)
-      )} />
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
+  }
+  if (readOnly) {
+    return (
+      <ReadOnlyDisplay
+        label={label}
+        value={thePConn.getLocalizedValue(
+          displayValue,
+          localePath,
+          thePConn.getLocaleRuleNameFromKeys(localeClass, localeContext, localeName)
+        )}
+      />
+    );
   }
 
-  const extraProps= {testProps:{'data-test-id':testId}};
+  const extraProps = { testProps: { 'data-test-id': testId } };
   const actionsApi = thePConn.getActionsApi();
   const propName = thePConn.getStateProps().value;
 
@@ -81,13 +103,15 @@ export default function RadioButtons(props) {
       label={label}
       onChange={handleChange}
       legendIsHeading={isOnlyField}
-      options={theOptions.map(option => {return {
-        value:option.key,
-        label:thePConn.getLocalizedValue(
-        option.value,
-        localePath,
-        thePConn.getLocaleRuleNameFromKeys(localeClass, localeContext, localeName)
-        )}
+      options={theOptions.map(option => {
+        return {
+          value: option.key,
+          label: thePConn.getLocalizedValue(
+            option.value,
+            localePath,
+            thePConn.getLocaleRuleNameFromKeys(localeClass, localeContext, localeName)
+          )
+        };
       })}
       displayInline={theOptions.length === 2}
       hintText={helperText}

--- a/src/components/override-sdk/field/RadioButtons/config-ext.json
+++ b/src/components/override-sdk/field/RadioButtons/config-ext.json
@@ -1,9 +1,22 @@
 {
-    "componentKey": "RadioButtons",
-    "name": "RadioButtons",
-    "label": "Radio buttons",
-    "description": "Picklist",
-    "type": "Field",
-    "subtype": "Picklist",
-    "properties": []
+  "componentKey": "RadioButtons",
+  "name": "RadioButtons",
+  "label": "Radio buttons",
+  "description": "Picklist",
+  "type": "Field",
+  "subtype": "Picklist",
+  "properties": [
+    {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    }
+  ]
 }

--- a/src/components/override-sdk/field/TextInput/TextInput.tsx
+++ b/src/components/override-sdk/field/TextInput/TextInput.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import GDSTextInput from '../../../BaseComponents/TextInput/TextInput';
 import useIsOnlyField from '../../../helpers/hooks/QuestionDisplayHooks';
 import ReadOnlyDisplay from '../../../BaseComponents/ReadOnlyDisplay/ReadOnlyDisplay';
 import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
-
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
+import GDSCheckAnswers from '../../../custom-sdk/field/HMRC_ODX_GDSCheckAnswersScreen';
+import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
 
 export default function TextInput(props) {
   const {
@@ -23,13 +24,13 @@ export default function TextInput(props) {
     configAlternateDesignSystem
   } = props;
 
-  const[errorMessage,setErrorMessage] = useState(validatemessage);
-
+  const [errorMessage, setErrorMessage] = useState(validatemessage);
+  const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
   registerNonEditableField(!!disabled);
 
-  useEffect(()=>{
-    setErrorMessage(validatemessage)
-  },[validatemessage])
+  useEffect(() => {
+    setErrorMessage(validatemessage);
+  }, [validatemessage]);
   const thePConn = getPConnect();
   const actionsApi = thePConn.getActionsApi();
 
@@ -44,13 +45,32 @@ export default function TextInput(props) {
   };
 
   let label = props.label;
-  const {isOnlyField, overrideLabel} = useIsOnlyField(props.displayOrder);
-  if(isOnlyField && !readOnly) label = overrideLabel.trim() ? overrideLabel : label;
+  const { isOnlyField, overrideLabel } = useIsOnlyField(props.displayOrder);
+  if (isOnlyField && !readOnly) label = overrideLabel.trim() ? overrideLabel : label;
 
   const maxLength = fieldMetadata?.maxLength;
+  if (hasBeenWrapped && configAlternateDesignSystem?.ShowChangeLink) {
+    return (
+      <GDSCheckAnswers
+        label={props.label}
+        value={value}
+        name={name}
+        stepId={configAlternateDesignSystem.stepId}
+        getPConnect={getPConnect}
+        required={false}
+        disabled={false}
+        validatemessage=''
+        onChange={undefined}
+        readOnly={false}
+        testId=''
+        helperText=''
+        hideLabel={false}
+      />
+    );
+  }
 
   if (readOnly) {
-    return <ReadOnlyDisplay label={label} value={value} name={name}/>;
+    return <ReadOnlyDisplay label={label} value={value} name={name} />;
   }
 
   const extraProps = { testProps: { 'data-test-id': testId } };

--- a/src/components/override-sdk/field/TextInput/config-ext.json
+++ b/src/components/override-sdk/field/TextInput/config-ext.json
@@ -7,6 +7,18 @@
   "subtype": "Text",
   "properties": [
     {
+      "name": "ShowChangeLink",
+      "label": "Show change link",
+      "format": "BOOLEAN"
+    },
+    {
+      "format": "TEXT",
+      "name": "stepId",
+      "label": "stepId for Changelink",
+      "required": false,
+      "visibility": "$this.ShowChangeLink"
+    },
+    {
       "format": "SELECT",
       "name": "autocomplete",
       "label": "Autocomplete attribute",


### PR DESCRIPTION
The changes are for revised check your answers screen.

1. A new custom component has been created called HMRC_ODX_GDSCheckAnswersScreen.
2. config of each OOTB component (date, text, radio buttons etc...) has been extended to include a 
-Check your answers 'true/false' config option
-If this is selected true, we can also show a text input for Step ID
3. And then we have added our override components to check if this config option is true, and render the component we've already built, otherwise just display the editable inputs 
 