### PR TITLE
US-12655 : Display delete claim screen when user refreshes a claim page in Un-Auth journey

### DIFF
--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -158,6 +158,7 @@ export default function DefaultForm(props) {
     const handleBeforeUnload = () => {
       // Perform actions before the component unloads
       sessionStorage.setItem('isAutocompleteRendered', 'false');
+      sessionStorage.setItem('isRefreshedOnClaim', 'true');
       PCore.getContainerUtils().closeContainerItem(
         PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
         { skipDirtyCheck: true }

--- a/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
@@ -8,6 +8,7 @@ export default function DeleteAnswers({ hasSessionTimedOut }) {
   const { t } = useTranslation();
   const history = useHistory();
   const redirectChoseClaim = () => {
+    sessionStorage.removeItem('isRefreshedOnClaim');
     history.push('/recently-claimed-child-benefit');
   };
   return (

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -81,9 +81,13 @@ export default function UnAuthChildBenefitsClaim() {
       startingFields = {
         NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0, 2) || 'en'
       };
-      PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
-        startingFields
-      });
+      if (sessionStorage.getItem('isRefreshedOnClaim') === 'true') {
+        setShowDeletePage(true);
+      } else {
+        PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
+          startingFields
+        });
+      }
     }
     setShowStartPage(false);
   }


### PR DESCRIPTION
As a part of this PR , we are adding changes where when claimant refreshes any page in un-auth claim , 

he/she will be landed on delete claim screen.

Another scenario : When on delete claim screen, if refreshed , should show delete claim screen only.

Once claimant clicked start claim again , he/she should be able to progress with new claim again.