### PR TITLE
BUG-8328 & 8326 - Fixed shuttering issue for unauth

### DIFF
--- a/src/components/helpers/utils.ts
+++ b/src/components/helpers/utils.ts
@@ -29,7 +29,7 @@ export const isUnAuthJourney = () => {
   );
   const context = PCore.getContainerUtils().getActiveContainerItemName(`${containername}/workarea`);
   const caseType = PCore.getStoreValue('.CaseType', 'caseInfo.content', context);
-  return caseType === 'Unauth';
+  return caseType === 'Unauth' || window.location.href.includes('/ua');
 };
 
 export const getServiceShutteredStatus = async (): Promise<boolean> => {


### PR DESCRIPTION
caseType is coming undefined when user land on tasklist which is 1st screen in unauth. So added check window.location.href.includes('/ua') to determine case is auth or unauth.