### PR TITLE
BUG-7400 - Address fields not grouped

### DIFF
--- a/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
+++ b/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
-import { func, string } from 'prop-types';
+import { bool, func, string } from 'prop-types';
 
 import HintTextComponent from '../../helpers/formatters/ParsedHtml';
-import FormGroup from '../FormGroup/FormGroup';
+import FieldSet from '../FormGroup/FieldSet';
 
 function makeHintId(identifier) {
   return `${identifier}-hint`;
@@ -15,7 +15,7 @@ declare global {
 }
 
 export default function AutoComplete(props) {
-  const { optionList, instructionText, selectedValue, testId, helperText, errorText, id } = props;
+  const { optionList, instructionText, selectedValue, testId, helperText, errorText, id, labelIsHeading } = props;
   const inputClasses = `govuk-input ${errorText ? 'govuk-input--error' : ''}`.trim();
 
   useEffect(() => {
@@ -52,8 +52,10 @@ export default function AutoComplete(props) {
     });
   };
 
+  const extraProps = { testProps: { 'data-test-id': testId }, isAutoCompleteLegendIsHeading:labelIsHeading, isAutoCompleteField:true};
+
   return (
-    <FormGroup {...props}>
+    <FieldSet {...props}  {...extraProps}>
       {helperText && (
         <div id={makeHintId(id)} className='govuk-hint'>
           <HintTextComponent htmlString={helperText} />
@@ -80,12 +82,12 @@ export default function AutoComplete(props) {
       ) : (
         <></>
       )}
-    </FormGroup>
+    </FieldSet>
   );
 }
 
 AutoComplete.propTypes = {
-  ...FormGroup.propTypes,
+  ...FieldSet.propTypes,
   optionList: { key: string, value: string },
   label: string,
   instructionText: string,
@@ -93,5 +95,7 @@ AutoComplete.propTypes = {
   onChange: func,
   selectedValue: string,
   testId: string,
-  name: string
+  name: string,
+  labelIsHeading: bool,
+  id: string
 };

--- a/src/components/BaseComponents/FormGroup/FieldSet.tsx
+++ b/src/components/BaseComponents/FormGroup/FieldSet.tsx
@@ -14,7 +14,9 @@ export default function FieldSet({
   hintText,
   children,
   fieldsetElementProps,
-  testProps
+  testProps,
+  isAutoCompleteField,
+  isAutoCompleteLegendIsHeading,
 }) {
   const { instructionText } = useContext(DefaultFormContext);
 
@@ -30,11 +32,16 @@ export default function FieldSet({
   const formGroupDivClasses = `govuk-form-group ${
     errMessage ? 'govuk-form-group--error' : ''
   }`.trim();
-  const legendClasses = ` ${
+  let legendClasses = ` ${
     legendIsHeading
       ? 'govuk-fieldset__legend govuk-fieldset__legend--l'
       : 'govuk-label govuk-label--m'
   }`.trim();
+
+  // to updte legend style for Autocomplete
+  legendClasses =  isAutoCompleteField && !isAutoCompleteLegendIsHeading ? 'govuk-label' : legendClasses;
+  legendClasses =  isAutoCompleteField && isAutoCompleteLegendIsHeading ? 'govuk-fieldset__legend govuk-fieldset__legend--l': legendClasses ;
+
   const hintTextExists = !['none', '', null, undefined].includes(hintText);
 
   // TODO Reconsider how to generate hintID and errorID for aria-described by

--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -82,6 +82,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
   const thePConn = getPConnect();
   const actionsApi = thePConn.getActionsApi();
   const propName = thePConn.getStateProps()['value'];
+  const formattedPropertyName = name || propName?.split('.')?.pop();
 
   useEffect(() => {
     const script = document.createElement('script');
@@ -235,7 +236,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
         testId={testId}
         labelIsHeading={isOnlyField}
         errorText={errorMessage}
-        id={name}
+        id={formattedPropertyName}
       />
     )
   );


### PR DESCRIPTION
**BUG-7400 - Address fields not grouped**

Issue: Missing fieldset and legend as address fields presented to screen reader users as separate fields without grouping. This will help SR users to identify how the page is structured.

Users presented visually with two separate groups of questions, however screen reader won't announce grouping of different sections without appropriate legend it makes hard for users to differentiate context of address fields.

Resolution: 
Wrapped address lookup fields in fieldset with additional legend

1. **BaseComponents/Autocomplete/Autocomplete.tsx** - Updated FormGroup element to FieldSet 
2. **FieldSet.tsx** -  Added Autocomplete element style condition
3. **override-sdk/field/AutoComplete/AutoComplete.tsx** - Assigned propName to id property when name is empty. 