### PR TITLE
Bug - 8123 : Claim getting locked in AUI after claimant clicked on save and come back later

### DIFF
--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -70,8 +70,8 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
       })
       .finally(() => {
         PCore.getPubSubUtils().publish('staySignedInOnConfirmationScreen', {});
-        //As the document API calls are executed as last ones , we want to close container as a very
-        //last call , so we even included 2.5 seconds of time gap for execution
+        //  As the document API calls are executed as last ones , we want to close container as a very
+        //  last call , so we even included 2.5 seconds of time gap for execution
         setTimeout(() => {
           PCore.getContainerUtils().closeContainerItem(
             PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),

--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -70,6 +70,12 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
       })
       .finally(() => {
         PCore.getPubSubUtils().publish('staySignedInOnConfirmationScreen', {});
+        setTimeout(() => {
+          PCore.getContainerUtils().closeContainerItem(
+            PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+            { skipDirtyCheck: true }
+          );
+        }, 2500);
       });
   }, []);
 

--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -70,6 +70,8 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
       })
       .finally(() => {
         PCore.getPubSubUtils().publish('staySignedInOnConfirmationScreen', {});
+        //As the document API calls are executed as last ones , we want to close container as a very
+        //last call , so we even included 2.5 seconds of time gap for execution
         setTimeout(() => {
           PCore.getContainerUtils().closeContainerItem(
             PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -202,6 +202,12 @@ export default function ChildBenefitsClaim() {
   }
   function assignmentFinished() {
     getClaimsCaseID();
+    if (!bShowResolutionScreen) {
+      PCore.getContainerUtils().closeContainerItem(
+        PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+        { skipDirtyCheck: true }
+      );
+    }
     displayResolutionScreen();
   }
 

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -238,8 +238,8 @@ export default function ChildBenefitsClaim() {
   }
 
   function cancelAssignment() {
-    //Here we are passing true as argument for below function because we will close container
-    //based on whether claimant has clicked save and come back later link.
+    //  Here we are passing true as argument for below function because we will close container
+    //  based on whether claimant has clicked save and come back later link.
     fetchInProgressClaimsData(true);
     getClaimsCaseID();
     displayUserPortal();

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -94,14 +94,11 @@ export default function ChildBenefitsClaim() {
   const [switchLang, setSwitchLang] = useState(lang);
 
   if (typeof PCore !== 'undefined') {
-    PCore.getPubSubUtils().subscribe(
-      'languageToggleTriggered',
-      (langreference) => {
-        setTimeout(() => {
-          setSwitchLang(langreference?.language);
-        }, 50);
-      }
-    );
+    PCore.getPubSubUtils().subscribe('languageToggleTriggered', langreference => {
+      setTimeout(() => {
+        setSwitchLang(langreference?.language);
+      }, 50);
+    });
   }
 
   function resetAppDisplay() {
@@ -205,10 +202,6 @@ export default function ChildBenefitsClaim() {
   }
   function assignmentFinished() {
     getClaimsCaseID();
-    PCore.getContainerUtils().closeContainerItem(
-      PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
-      { skipDirtyCheck: true }
-    );
     displayResolutionScreen();
   }
 
@@ -219,7 +212,7 @@ export default function ChildBenefitsClaim() {
   // Calls data page to fetch in progress claims, then for each result (limited to first 10), calls D_Claim to get extra details about each 'assignment'
   // to display within the claim 'card' in the list. This then sets inprogress claims state value to the list of claims data.
   // This funtion also sets 'isloading' value to true before making d_page calls, and sets it back to false after data claimed.
-  function fetchInProgressClaimsData() {
+  function fetchInProgressClaimsData(isSaveComeBackClicked = false) {
     setLoadingInProgressClaims(true);
     let inProgressClaimsData: any = [];
     // @ts-ignore
@@ -230,17 +223,21 @@ export default function ChildBenefitsClaim() {
         inProgressClaimsData = resp;
         setInprogressClaims(inProgressClaimsData);
         setLoadingInProgressClaims(false);
+      })
+      .finally(() => {
+        if (isSaveComeBackClicked === true) {
+          PCore.getContainerUtils().closeContainerItem(
+            PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+            { skipDirtyCheck: true }
+          );
+        }
       });
   }
 
   function cancelAssignment() {
-    fetchInProgressClaimsData();
+    fetchInProgressClaimsData(true);
     getClaimsCaseID();
     displayUserPortal();
-    PCore.getContainerUtils().closeContainerItem(
-      PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
-      { skipDirtyCheck: true }
-    );
   }
 
   async function setShutterStatus() {
@@ -641,7 +638,7 @@ export default function ChildBenefitsClaim() {
                 rowClickAction='OpenAssignment'
                 buttonContent={t('CONTINUE_CLAIM')}
                 caseId={caseId}
-                switchLang ={switchLang}
+                switchLang={switchLang}
               />
             )}
 
@@ -653,7 +650,7 @@ export default function ChildBenefitsClaim() {
                 rowClickAction='OpenCase'
                 buttonContent={t('VIEW_CLAIM')}
                 checkShuttered={checkShuttered}
-                switchLang ={switchLang}
+                switchLang={switchLang}
               />
             )}
           </UserPortal>

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -225,7 +225,7 @@ export default function ChildBenefitsClaim() {
         setLoadingInProgressClaims(false);
       })
       .finally(() => {
-        if (isSaveComeBackClicked === true) {
+        if (isSaveComeBackClicked) {
           // Here we are calling this close container because of the fact that above
           // D_ClaimantWorkAssignmentChBCases API is getting excuted as last call but we want to make
           // close container call as the very last one.

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -226,6 +226,9 @@ export default function ChildBenefitsClaim() {
       })
       .finally(() => {
         if (isSaveComeBackClicked === true) {
+          // Here we are calling this close container because of the fact that above
+          // D_ClaimantWorkAssignmentChBCases API is getting excuted as last call but we want to make
+          // close container call as the very last one.
           PCore.getContainerUtils().closeContainerItem(
             PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
             { skipDirtyCheck: true }
@@ -235,6 +238,8 @@ export default function ChildBenefitsClaim() {
   }
 
   function cancelAssignment() {
+    //Here we are passing true as argument for below function because we will close container
+    //based on whether claimant has clicked save and come back later link.
     fetchInProgressClaimsData(true);
     getClaimsCaseID();
     displayUserPortal();

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -133,6 +133,12 @@ export default function UnAuthChildBenefitsClaim() {
 
   function assignmentFinished() {
     getClaimsCaseID();
+    if (!bShowResolutionScreen) {
+      PCore.getContainerUtils().closeContainerItem(
+        PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+        { skipDirtyCheck: true }
+      );
+    }
     resetAppDisplay();
     setShowResolutionScreen(true);
   }

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -133,7 +133,6 @@ export default function UnAuthChildBenefitsClaim() {
 
   function assignmentFinished() {
     getClaimsCaseID();
-    closeContainer();
     resetAppDisplay();
     setShowResolutionScreen(true);
   }


### PR DESCRIPTION
As a part of this PR , we have provided fix for lock issue in AUI , when claimant clicked save and comeback later link.

Also we provided fix at the confirmation page after submission of entire claim , we are calling close container API after 2.5 seconds of rendering the confirmation page , so that it will be executed at very last.