### PR TITLE
Bug-8340 : page title not reflecting for shuttering service page

### DIFF
--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -140,7 +140,7 @@ export default function ChildBenefitsClaim() {
 
   useEffect(() => {
     setPageTitle();
-  }, [showStartPage, showUserPortal, bShowPega, bShowResolutionScreen]);
+  }, [showStartPage, showUserPortal, bShowPega, bShowResolutionScreen, shutterServicePage]);
 
   const [inprogressClaims, setInprogressClaims] = useState([]);
   const [submittedClaims, setSubmittedClaims] = useState([]);

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -100,7 +100,7 @@ export default function UnAuthChildBenefitsClaim() {
 
   useEffect(() => {
     setPageTitle();
-  }, [showStartPage, bShowPega, bShowResolutionScreen]);
+  }, [showStartPage, bShowPega, bShowResolutionScreen, shutterServicePage]);
 
   function closeContainer() {
     PCore.getContainerUtils().closeContainerItem(


### PR DESCRIPTION
As a part of this PR , we have included the changes to useEffect hooks in both auth and un-auth index.tsx pages, 

we included shutter service state variable in useEffect dependencies array , so it will call pageTitle when changed.