### PR TITLE
US12655-1: Claimant will land on same screen on browser refresh

### DIFF
--- a/src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/index.tsx
+++ b/src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import { Grid } from '@pega/cosmos-react-core';
 import { useTranslation } from 'react-i18next';
 import type { PConnProps } from '@pega/react-sdk-components/lib/types/PConnProps';
@@ -38,6 +38,10 @@ export default function HmrcOdxGdsTaskListTemplate(props: HmrcOdxGdsTaskListTemp
       completedSections += 1;
     }
   });
+
+  useEffect(() => {
+    sessionStorage.removeItem('assignmentID');
+  }, []);
 
   const handleOnClick = (section: string) => {
     getPConnect().setValue('.SelectedTask', section, '', false);

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -158,6 +158,11 @@ export default function DefaultForm(props) {
     const handleBeforeUnload = () => {
       // Perform actions before the component unloads
       sessionStorage.setItem('isAutocompleteRendered', 'false');
+
+      const thePConn = getPConnect();
+      const assignmentID = thePConn.getCaseInfo().getAssignmentID();
+      sessionStorage.setItem('assignmentID', assignmentID);
+
       PCore.getContainerUtils().closeContainerItem(
         PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
         { skipDirtyCheck: true }

--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -27,6 +27,7 @@ const ConfirmationPage = ({ caseId, isUnAuth }) => {
       : 'https://www.tax.service.gov.uk/feedback/ODXCHB';
   }
   useEffect(() => {
+    sessionStorage.removeItem('assignmentID');
     setPageTitle();
   }, []);
 

--- a/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
@@ -8,8 +8,10 @@ export default function DeleteAnswers({ hasSessionTimedOut }) {
   const { t } = useTranslation();
   const history = useHistory();
   const redirectChoseClaim = () => {
+    sessionStorage.removeItem('assignmentID');
     history.push('/recently-claimed-child-benefit');
   };
+
   return (
     <MainWrapper>
       <h1 className='govuk-heading-l'>

--- a/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import MainWrapper from '../../components/BaseComponents/MainWrapper';
 import Button from '../../components/BaseComponents/Button/Button';
@@ -8,9 +8,12 @@ export default function DeleteAnswers({ hasSessionTimedOut }) {
   const { t } = useTranslation();
   const history = useHistory();
   const redirectChoseClaim = () => {
-    sessionStorage.removeItem('assignmentID');
     history.push('/recently-claimed-child-benefit');
   };
+
+  useEffect(() => {
+    sessionStorage.removeItem('assignmentID');
+  }, []);
 
   return (
     <MainWrapper>

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -77,14 +77,31 @@ export default function UnAuthChildBenefitsClaim() {
       resetAppDisplay();
       setShowPega(true);
 
+      const pyAssignmentID = sessionStorage.getItem('assignmentID');
       let startingFields = {};
       startingFields = {
         NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0, 2) || 'en'
       };
-      PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
-        startingFields
-      });
+      if (!pyAssignmentID) {
+        PCore.getMashupApi()
+          .createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
+            startingFields
+          })
+          .then(() => {});
+      } else {
+        const container = pConn.getContainerName();
+        const target = `${PCore.getConstants().APP.APP}/${container}`;
+        const openAssignmentOptions = { containerName: container };
+        const pyAssignmentID = sessionStorage.getItem('assignmentID');
+        PCore.getMashupApi()
+          .openAssignment(pyAssignmentID, target, openAssignmentOptions)
+          .then(() => {
+            //scrollToTop();
+          })
+          .catch((err: Error) => console.log('Error : ', err)); // eslint-disable-line no-console
+      }
     }
+
     setShowStartPage(false);
   }
 

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -83,11 +83,9 @@ export default function UnAuthChildBenefitsClaim() {
         NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0, 2) || 'en'
       };
       if (!pyAssignmentID) {
-        PCore.getMashupApi()
-          .createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
-            startingFields
-          })
-          .then(() => {});
+        PCore.getMashupApi().createCase('HMRC-ChB-Work-Claim', PCore.getConstants().APP.APP, {
+          startingFields
+        });
       } else {
         const container = pConn.getContainerName();
         const target = `${PCore.getConstants().APP.APP}/${container}`;

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -28,7 +28,7 @@ import {
 import DeleteAnswers from './deleteAnswers';
 import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
 import toggleNotificationProcess from '../../components/helpers/toggleNotificationLanguage';
-import { getServiceShutteredStatus } from '../../components/helpers/utils';
+import { getServiceShutteredStatus, scrollToTop } from '../../components/helpers/utils';
 
 declare const myLoadMashup: Function;
 
@@ -92,11 +92,11 @@ export default function UnAuthChildBenefitsClaim() {
         const container = pConn.getContainerName();
         const target = `${PCore.getConstants().APP.APP}/${container}`;
         const openAssignmentOptions = { containerName: container };
-        const pyAssignmentID = sessionStorage.getItem('assignmentID');
+        const assignmentID = sessionStorage.getItem('assignmentID');
         PCore.getMashupApi()
-          .openAssignment(pyAssignmentID, target, openAssignmentOptions)
+          .openAssignment(assignmentID, target, openAssignmentOptions)
           .then(() => {
-            //scrollToTop();
+            scrollToTop();
           })
           .catch((err: Error) => console.log('Error : ', err)); // eslint-disable-line no-console
       }


### PR DESCRIPTION
Tested the below scenario

Refresh on:
TaskList - fresh case
Static pages - no impact
Assignments - land into same screen
CYA -land on same screen
Confirmation - fresh case
Delete screen - fresh case

Solution - saving the assignment id on browser refresh and navigating user to same screen when we found assignment id.