### PR TITLE
Bug 8302 user portal displaying on new claim

### DIFF
--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -94,14 +94,11 @@ export default function ChildBenefitsClaim() {
   const [switchLang, setSwitchLang] = useState(lang);
 
   if (typeof PCore !== 'undefined') {
-    PCore.getPubSubUtils().subscribe(
-      'languageToggleTriggered',
-      (langreference) => {
-        setTimeout(() => {
-          setSwitchLang(langreference?.language);
-        }, 50);
-      }
-    );
+    PCore.getPubSubUtils().subscribe('languageToggleTriggered', langreference => {
+      setTimeout(() => {
+        setSwitchLang(langreference?.language);
+      }, 50);
+    });
   }
 
   function resetAppDisplay() {
@@ -248,7 +245,8 @@ export default function ChildBenefitsClaim() {
     setShutterServicePage(status);
     if (status) {
       resetAppDisplay();
-    } else {
+      // Checking that the assignmentPConn isn't populated so user portal is hidden in assignemnt.
+    } else if (!status && !assignmentPConn === null) {
       displayUserPortal();
     }
   }
@@ -641,7 +639,7 @@ export default function ChildBenefitsClaim() {
                 rowClickAction='OpenAssignment'
                 buttonContent={t('CONTINUE_CLAIM')}
                 caseId={caseId}
-                switchLang ={switchLang}
+                switchLang={switchLang}
               />
             )}
 
@@ -653,7 +651,7 @@ export default function ChildBenefitsClaim() {
                 rowClickAction='OpenCase'
                 buttonContent={t('VIEW_CLAIM')}
                 checkShuttered={checkShuttered}
-                switchLang ={switchLang}
+                switchLang={switchLang}
               />
             )}
           </UserPortal>

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -241,13 +241,19 @@ export default function ChildBenefitsClaim() {
   }
 
   async function setShutterStatus() {
-    const status = await getServiceShutteredStatus();
-    setShutterServicePage(status);
-    if (status) {
-      resetAppDisplay();
-      // Checking that the assignmentPConn isn't populated so user portal stays hidden in assignemnt.
-    } else if (!status && !assignmentPConn === null) {
-      displayUserPortal();
+    try {
+      const status = await getServiceShutteredStatus();
+      setShutterServicePage(status);
+
+      if (status) {
+        resetAppDisplay();
+        // Ensure assignmentPConn isn't populated to keep the user portal hidden during assignment.
+      } else if (!status && !assignmentPConn === null) {
+        displayUserPortal();
+      }
+    } catch (error) {
+      // Handle error appropriately, e.g., log it or show a notification
+      console.error('Error setting shutter status:', error);
     }
   }
 

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -248,12 +248,12 @@ export default function ChildBenefitsClaim() {
       if (status) {
         resetAppDisplay();
         // Ensure assignmentPConn isn't populated to keep the user portal hidden during assignment.
-      } else if (!status && !assignmentPConn === null) {
+      } else if (!status && assignmentPConn !== null) {
         displayUserPortal();
       }
     } catch (error) {
       // Handle error appropriately, e.g., log it or show a notification
-      console.error('Error setting shutter status:', error);
+      console.error('Error setting shutter status:', error); // eslint-disable-line
     }
   }
 

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -245,7 +245,7 @@ export default function ChildBenefitsClaim() {
     setShutterServicePage(status);
     if (status) {
       resetAppDisplay();
-      // Checking that the assignmentPConn isn't populated so user portal is hidden in assignemnt.
+      // Checking that the assignmentPConn isn't populated so user portal stays hidden in assignemnt.
     } else if (!status && !assignmentPConn === null) {
       displayUserPortal();
     }


### PR DESCRIPTION
This is to fix the bug where the user portal is showing when a user starts a new claim. I've added a check to see if the "assignmentPConn" isn't it's default value (null) as it's populated when a user is in the assignment. Because I've added a little more complexity to the async function (line 243) I've put it in a try, catch block. 