### PR TITLE
BUG-6776 Error summary is not in sequence at top

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -150,6 +150,20 @@ export default function Assignment(props) {
     }
   }, [children]);
 
+  function sortErrorMessages(errorMsg) {
+    const formElements = document.forms[0].elements;
+    let sortedErrors = [];
+
+    for (let i=0; i<formElements.length; i++){
+      errorMsg.forEach(err => { 
+        if(formElements[i]?.id == err?.message?.fieldId) {
+          sortedErrors.push(err);
+        }
+      });
+    }
+    return sortedErrors;
+  }
+
   function checkErrorMessages() {
     let errorStateProps = [];
     errorStateProps = PCore.getFormUtils()
@@ -208,6 +222,10 @@ export default function Assignment(props) {
         return acc;
       }, []);
 
+    // To sort error message based on form field order
+    if (errorStateProps.length > 0) {
+      errorStateProps = sortErrorMessages(errorStateProps);
+    }
     setErrorMessages([...errorStateProps]);
   }
 


### PR DESCRIPTION
**BUG-6776 Error summary is not in sequence at top**

**Issue:** Error messages at the top of the screen (Error summary) are not in the sequence order.

**Resolution:** 
1. **Assignment.tsx** - Added sorting to error message summary based on form field sequence. 