### PR TITLE
US-12655 : Issue around delete screen appearing for entier timeout is fixed

### DIFF
--- a/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/deleteAnswers.tsx
@@ -9,6 +9,8 @@ export default function DeleteAnswers({ hasSessionTimedOut }) {
   const history = useHistory();
   const redirectChoseClaim = () => {
     sessionStorage.removeItem('isRefreshFromDeleteScreen');
+    sessionStorage.removeItem('hasSessionTimedOut');
+    sessionStorage.removeItem('isTasklistClicked');
     history.push('/recently-claimed-child-benefit');
   };
 


### PR DESCRIPTION
As a part of this PR , we fixed delete screen issue on entire timeout by removing the session storage items.