### PR TITLE
Bug 7756 - Incorrect error message and Back button issue

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -293,7 +293,7 @@ export default function Assignment(props) {
     });
   }
 
-  function handleBackLinkforDateComp(){
+  function handleBackLinkforInvalidDate(){
     const childPconnect = children[0]?.props?.getPConnect();
     const dateField = PCore.getFormUtils().getEditableFields(childPconnect.getContextName()).filter(field => field.type.toLowerCase() === 'date');
     if(dateField){
@@ -315,7 +315,7 @@ export default function Assignment(props) {
     if (sButtonType === 'secondary') {
       switch (sAction) {
         case 'navigateToStep': {
-          handleBackLinkforDateComp(); // clears the date value if there is invalid date, allowing back btn click(ref bug-7756) 
+          handleBackLinkforInvalidDate(); // clears the date value if there is invalid date, allowing back btn click(ref bug-7756) 
           const navigatePromise = navigateToStep('previous', itemKey);
 
           clearErrors();

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -298,12 +298,12 @@ export default function Assignment(props) {
     const dateField = PCore.getFormUtils().getEditableFields(childPconnect.getContextName()).filter(field => field.type.toLowerCase() === 'date');
     if(dateField){
       dateField?.forEach(field => {
-        const childPagRef = children[0]?.props?.getPConnect().getPageReference();
+        const childPagRef = childPconnect.getPageReference();
         const pageRef = thePConn.getPageReference() === childPagRef ? thePConn.getPageReference() : childPagRef;
         const storedRefName = field.name?.replace(pageRef, '');
-        const storedDateValue = children[0]?.props?.getPConnect().getValue(`.${storedRefName}`);
+        const storedDateValue = childPconnect.getValue(`.${storedRefName}`);
         if(!dayjs(storedDateValue, 'YYYY-MM-DD', true).isValid()) {
-          children[0]?.props?.getPConnect().setValue(`.${storedRefName}`,'');
+          childPconnect.setValue(`.${storedRefName}`,'');
         }
       })
     }

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -312,7 +312,7 @@ export default function Assignment(props) {
     if (sButtonType === 'secondary') {
       switch (sAction) {
         case 'navigateToStep': {
-          handleBackLinkforDateComp(); //empty the date only if invalid date for Bug-7756
+          handleBackLinkforDateComp(); //clears the date value if there is invalid date, allowing back btn click(ref bug-7756) 
           const navigatePromise = navigateToStep('previous', itemKey);
 
           clearErrors();

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -22,6 +22,7 @@ import { ErrorMsgContext } from '../../../helpers/HMRCAppContext';
 import useServiceShuttered from '../../../helpers/hooks/useServiceShuttered';
 import StoreContext from '@pega/react-sdk-components/lib/bridge/Context/StoreContext';
 import AppContext from '../../../../samples/HighIncomeCase/reuseables/AppContext';
+import dayjs from 'dayjs';
 
 export interface ErrorMessageDetails {
   message: string;
@@ -270,12 +271,26 @@ export default function Assignment(props) {
     });
   }
 
+  function handleBackLinkforDateComp(){
+    const childPconnect = children[0]?.props?.getPConnect();
+    const dateField = PCore.getFormUtils().getEditableFields(childPconnect.getContextName()).filter(field => field.type.toLowerCase() === 'date');
+    if(dateField){
+      dateField?.forEach((field, index) => {
+        const stroredDateValue = children[0]?.props?.getPConnect().getValue('.' + field.name?.replace(thePConn.getPageReference(), ''));
+        if(!dayjs(stroredDateValue, 'YYYY-MM-DD', true).isValid()) {
+          children[0]?.props?.getPConnect().setValue('.' + field.name?.replace(thePConn.getPageReference(), ''), '');
+        }
+      })
+    }
+  }
+
   async function buttonPress(sAction: string, sButtonType: string) {
     setErrorSummary(false);
 
     if (sButtonType === 'secondary') {
       switch (sAction) {
         case 'navigateToStep': {
+          handleBackLinkforDateComp(); //empty the date only if invalid date for Bug-7756
           const navigatePromise = navigateToStep('previous', itemKey);
 
           clearErrors();

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -298,9 +298,12 @@ export default function Assignment(props) {
     const dateField = PCore.getFormUtils().getEditableFields(childPconnect.getContextName()).filter(field => field.type.toLowerCase() === 'date');
     if(dateField){
       dateField?.forEach(field => {
-        const stroredDateValue = children[0]?.props?.getPConnect().getValue(`.${field.name?.replace(thePConn.getPageReference(), '')}`);
-        if(!dayjs(stroredDateValue, 'YYYY-MM-DD', true).isValid()) {
-          children[0]?.props?.getPConnect().setValue(`.${field.name?.replace(thePConn.getPageReference(), '')}`,'');
+        const childPagRef = children[0]?.props?.getPConnect().getPageReference();
+        const pageRef = thePConn.getPageReference() === childPagRef ? thePConn.getPageReference() : childPagRef;
+        const storedRefName = field.name?.replace(pageRef, '');
+        const storedDateValue = children[0]?.props?.getPConnect().getValue(`.${storedRefName}`);
+        if(!dayjs(storedDateValue, 'YYYY-MM-DD', true).isValid()) {
+          children[0]?.props?.getPConnect().setValue(`.${storedRefName}`,'');
         }
       })
     }

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -297,10 +297,10 @@ export default function Assignment(props) {
     const childPconnect = children[0]?.props?.getPConnect();
     const dateField = PCore.getFormUtils().getEditableFields(childPconnect.getContextName()).filter(field => field.type.toLowerCase() === 'date');
     if(dateField){
-      dateField?.forEach((field, index) => {
-        const stroredDateValue = children[0]?.props?.getPConnect().getValue('.' + field.name?.replace(thePConn.getPageReference(), ''));
+      dateField?.forEach(field => {
+        const stroredDateValue = children[0]?.props?.getPConnect().getValue(`.${field.name?.replace(thePConn.getPageReference(), '')}`);
         if(!dayjs(stroredDateValue, 'YYYY-MM-DD', true).isValid()) {
-          children[0]?.props?.getPConnect().setValue('.' + field.name?.replace(thePConn.getPageReference(), ''), '');
+          children[0]?.props?.getPConnect().setValue(`.${field.name?.replace(thePConn.getPageReference(), '')}`,'');
         }
       })
     }
@@ -312,7 +312,7 @@ export default function Assignment(props) {
     if (sButtonType === 'secondary') {
       switch (sAction) {
         case 'navigateToStep': {
-          handleBackLinkforDateComp(); //clears the date value if there is invalid date, allowing back btn click(ref bug-7756) 
+          handleBackLinkforDateComp(); // clears the date value if there is invalid date, allowing back btn click(ref bug-7756) 
           const navigatePromise = navigateToStep('previous', itemKey);
 
           clearErrors();


### PR DESCRIPTION
**BUG-7756(Incorrect error message and Back button issue)**

The fix is about for allowing back button click when there is invalid date(it means if the user leave any one value of MM, DD, or YYYY as empty or  invalid value). Because the Pega API is expecting valid date or empty date. 
Now we clear the date value if there is invalid date and allowing back button click. 

**Assignment.tsx**: New method added in back link action. It will check only on date component with click action and clears the date value if there is invalid date.

