### PR TITLE
BUG-8354 , BUG-8353 (HICBC) - Fix redirect after signout

### DIFF
--- a/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
+++ b/src/components/AppComponents/TimeoutPopup/timeOutUtils.tsx
@@ -32,7 +32,7 @@ export const initTimeout = async (showTimeoutModal, deleteData, isAuthorised, is
     // TODO - unauth and sessiontimeout functionality to be implemented
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
-      if (!isAuthorised && !isConfirmationPage) {
+      if (!isAuthorised && !isConfirmationPage && deleteData) {
         // if the journey is not authorized or from confirmation page , the claim data gets deleted
         deleteData();
         clearTimer();
@@ -53,7 +53,7 @@ export const resetTimeout = (showTimeoutModal, deleteData, isAuthorised, isConfi
     // TODO - unauth and sessiontimeout functionality to be implemented
     showTimeoutModal(true);
     signoutTimeout = setTimeout(() => {
-      if (!isAuthorised && !isConfirmationPage) {
+      if (!isAuthorised && !isConfirmationPage && deleteData) {
         // if the journey is not authorized or from confirmation page , the claim data gets deleted
         deleteData();
         clearTimer();

--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -19,6 +19,7 @@ import { getSdkConfig } from '@pega/auth/lib/sdk-auth-manager';
 import useHMRCExternalLinks from '../../components/helpers/hooks/HMRCExternalLinks';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
 import AppContext from './reuseables/AppContext';
+import { triggerLogout } from '../../components/helpers/utils';
 
 // declare const myLoadMashup;
 
@@ -36,24 +37,8 @@ const ClaimPage: FunctionComponent<any> = () => {
     
     const history = useHistory();
 
-    function signOut() {
-      //  const authService = authType === 'gg' ? 'GovGateway' : (authType === 'gg-dev' ? 'GovGateway-Dev' : authType);
-      let authService;
-      if (authType && authType === 'gg') {
-        authService = 'GovGateway';
-      } else if (authType && authType === 'gg-dev') {
-        authService = 'GovGateway-Dev';
-      }
-      const dpprom = PCore.getDataPageUtils().getPageDataAsync('D_AuthServiceLogout', 'root', {
-        AuthService: authService
-      }) as Promise<object>;
-      dpprom.then(() => {
-        logout().then(() => {});
-      });
-    }
-
-    const redirectToLandingPage = () => {
-      signOut();
+     const redirectToLandingPage = () => {
+      triggerLogout();
       appBacklinkProps.appBacklinkAction();
     }
 
@@ -113,9 +98,9 @@ const ClaimPage: FunctionComponent<any> = () => {
 
   function handleSignout() {
         if (currentDisplay==='pegapage') {
-        setShowSignoutModal(true);
+          setShowSignoutModal(true);
         } else {
-        signOut();
+          triggerLogout();
         }
   }  
 
@@ -201,7 +186,7 @@ const ClaimPage: FunctionComponent<any> = () => {
         staySignedinHandler={() =>
           staySignedIn(setShowTimeoutModal, 'D_ClaimantWorkAssignmentChBCases')
         }
-        signoutHandler={() => logout()}
+        signoutHandler={triggerLogout}
         isAuthorised={false}  
         signoutButtonText="Sign out"
         staySignedInButtonText="Stay signed in"
@@ -245,7 +230,7 @@ const ClaimPage: FunctionComponent<any> = () => {
       <LogoutPopup
         show={showSignoutModal && !showTimeoutModal}
         hideModal={() => setShowSignoutModal(false)}
-        handleSignoutModal={signOut}
+        handleSignoutModal={triggerLogout}
         handleStaySignIn={handleStaySignIn}
         staySignedInButtonText='Stay signed in'
         signoutButtonText='Sign out'


### PR DESCRIPTION
Issue has been observed in HICBC claim that nothing appears to happen after clicking signout button in modals, or after timeout has passed.
This was due to missed call to redirect in HICBC 'journey' configuration.

Now pointing all to the shared 'triggerLogout' functionality to make use of the shared logout logic.


Also adds extra check to ensure that delete data function is set in timeoutUtils before trying to call it.