### PR TITLE
BUG-8418 - Update backlink text to reflect that user will be logged out

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -259,6 +259,7 @@
   "HICBC_LANDINGPAGE_NO_OPTION_SELECTED_ERROR_MESSAGE": "Select a date to opt-in",
 
   "BACK_TO_START_PAGE": "Back to start page",
+  "CLICK_TO_LOGOUT": "Click to log out",
 
   "SELECT_CHILD_BENEFIT_SERVICE": "Select which Child Benefit service you would like to use",
   "AUTOMATICALLY_CLOSE_IN": "This page will automatically close in",

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -482,7 +482,7 @@ export default function Assignment(props) {
                   key='createstagebacklink'
                   attributes={{ type: 'link' }}
                 >
-                  {appBacklinkProps.appBacklinkText}
+                  {t(appBacklinkProps.appBacklinkText as string)}
                 </Button>
               )
           }

--- a/src/samples/AppSelector/index.tsx
+++ b/src/samples/AppSelector/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-http-backend';
@@ -14,6 +14,9 @@ import CheckOnClaim from '../StaticPages/CheckOnClaim';
 import RecentlyClaimedChildBenefit from '../StaticPages/ChooseClaimService';
 
 const AppSelector = () => {
+
+  const [i18nloaded, seti18nloaded] = useState(false);
+
   i18n
     .use(Backend)
     .use(initReactI18next)
@@ -29,9 +32,12 @@ const AppSelector = () => {
       react: {
         useSuspense: false
       }
+    }).finally(() => {
+      seti18nloaded(true);
     });
 
   return (
+    !i18nloaded ? null :
     <Switch>
       <Route exact path='/' component={ChildBenefitsClaim} />
       <Route exact path='/ua' component={UnAuthChildBenefitsClaim} />

--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -39,7 +39,6 @@ const ClaimPage: FunctionComponent<any> = () => {
 
      const redirectToLandingPage = () => {
       triggerLogout();
-      appBacklinkProps.appBacklinkAction();
     }
 
     const [showTimeoutModal, setShowTimeoutModal] = useState(false);  
@@ -48,7 +47,7 @@ const ClaimPage: FunctionComponent<any> = () => {
     const { hmrcURL } = useHMRCExternalLinks();
 
     useEffect(() => 
-        {initTimeout(setShowTimeoutModal, false, true, false) }  
+        {initTimeout(setShowTimeoutModal, false, true, false) }
     , []);
     
     function doRedirectDone() {
@@ -56,10 +55,10 @@ const ClaimPage: FunctionComponent<any> = () => {
         // appName and mainRedirect params have to be same as earlier invocation
         loginIfNecessary({ appName: 'embedded', mainRedirect: true });        
     } 
-    
-    const { showPega, setShowPega, showResolutionPage, caseId } = useStartMashup(setAuthType, doRedirectDone, {appBacklinkProps:{appBacklinkAction: redirectToLandingPage}});
-    
 
+    const { showPega, setShowPega, showResolutionPage, caseId } = useStartMashup(setAuthType, doRedirectDone, {appBacklinkProps:{appBacklinkAction: redirectToLandingPage, appBacklinkText:t("CLICK_TO_LOGOUT")}});
+    
+    
     useEffect(() => {
       if(showPega){setCurrentDisplay('pegapage')}
       else if(showResolutionPage){
@@ -222,7 +221,7 @@ const ClaimPage: FunctionComponent<any> = () => {
               summaryTitle={summaryPageContent.title}
               summaryBanner={summaryPageContent.banner}
               backlinkProps={{backlinkAction:redirectToLandingPage,
-                              backlinkText:t('BACK_TO_START_PAGE')}}  
+                              backlinkText:t('CLICK_TO_LOGOUT')}}  
             />}        
           </>
         )}

--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect, useContext } from 'react';
+import React, { FunctionComponent, useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
@@ -18,7 +18,6 @@ import SummaryPage from '../../components/AppComponents/SummaryPage';
 import { getSdkConfig } from '@pega/auth/lib/sdk-auth-manager';
 import useHMRCExternalLinks from '../../components/helpers/hooks/HMRCExternalLinks';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
-import AppContext from './reuseables/AppContext';
 import { triggerLogout } from '../../components/helpers/utils';
 
 // declare const myLoadMashup;
@@ -32,7 +31,6 @@ const ClaimPage: FunctionComponent<any> = () => {
 
     const [currentDisplay, setCurrentDisplay] = useState<|'pegapage'|'resolutionpage'|'servicenotavailable'|'shutterpage'|'loading'>('pegapage');
     const [summaryPageContent, setSummaryPageContent] = useState<{content:string|null, title:string|null, banner:string|null}>({content:null, title:null, banner:null})
-    const { appBacklinkProps } = useContext(AppContext);
     const { t } = useTranslation();
     
     const history = useHistory();


### PR DESCRIPTION
Due to recent changes to logout logic, which now needs to redirect to the Gov Gateway signout url, the 'back' buttons on the first page or Summary pages no longer returns the user to the landing page. 
This change is a short term fix to reword the back links to better reflect what will happen for the user, until expected redirection can be handled.