### PR TITLE
Bug 8265 - Duplicate declaration text and warning.

### DIFF
--- a/sdk-local-component-map.js
+++ b/sdk-local-component-map.js
@@ -27,6 +27,7 @@ import HmrcOdxGdsTaskList from './src/components/custom-sdk/widget/HMRC_ODX_GDST
 import HmrcOdxGdsTaskListTemplate from './src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/';
 import AutoComplete from './src/components/override-sdk/field/AutoComplete/';
 import HmrcOdxGdsTextPresentation from './src/components/custom-sdk/field/HMRC_ODX_GDSTextPresentation/';
+import RichText from './src/components/override-sdk/field/RichText/';
 /*import end - DO NOT REMOVE*/
 
 // localSdkComponentMap is the JSON object where we'll store the components that are
@@ -53,6 +54,7 @@ const localSdkComponentMap = {
   Group: TemplateFieldGroupTemplate,
   Details: TemplateDetails,
   ViewContainer: InfraViewContainer,
+  RichText: RichText,
   HMRC_ODX_GDSInfoPanel: HmrcOdxGdsInfoPanel,
   HMRC_ODX_GDSSummaryCard: HmrcOdxGdsSummaryCard,
   HMRC_ODX_GDSButton: HmrcOdxGdsButton,

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
 import ParsedHTML from '../../../helpers/formatters/ParsedHtml';
 
-export default function RichText(props) {
-  // Checking to see if the html includes a p tag.
-  // If so we can add the 'govuk-body' class to a div as below
-  const containsParagraphTag = props.value.indexOf('<p>') !== -1;
+export default function RichText({ value }) {
+  const containsParagraphTag = value.includes('<p>');
 
   return (
     <>
-      {containsParagraphTag ? (
+      {containsParagraphTag && (
         <div className='govuk-body'>
-          <ParsedHTML htmlString={props.value} />
+          <ParsedHTML htmlString={value} />
         </div>
-      ) : (
-        <ParsedHTML htmlString={props.value} />
       )}
+      {!containsParagraphTag && <ParsedHTML htmlString={value} />}
     </>
   );
 }

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ParsedHTML from '../../../helpers/formatters/ParsedHtml';
 
 export default function RichText(props) {
+  // Checking to see if the html includes a p tag.
+  // If so we can add the 'govuk-body' class to a div as below
   const containsParagraphTag = props.value.indexOf('<p>') !== -1;
 
   return (

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ParsedHTML from '../../../helpers/formatters/ParsedHtml';
+
+export default function RichText(props) {
+  const containsParagraphTag = props.value.indexOf('<p>') !== -1;
+
+  return (
+    <>
+      {containsParagraphTag ? (
+        <div className='govuk-body'>
+          <ParsedHTML htmlString={props.value} />
+        </div>
+      ) : (
+        <ParsedHTML htmlString={props.value} />
+      )}
+    </>
+  );
+}

--- a/src/components/override-sdk/field/RichText/RichText.tsx
+++ b/src/components/override-sdk/field/RichText/RichText.tsx
@@ -6,12 +6,13 @@ export default function RichText({ value }) {
 
   return (
     <>
-      {containsParagraphTag && (
+      {containsParagraphTag ? (
         <div className='govuk-body'>
           <ParsedHTML htmlString={value} />
         </div>
+      ) : (
+        <ParsedHTML htmlString={value} />
       )}
-      {!containsParagraphTag && <ParsedHTML htmlString={value} />}
     </>
   );
 }

--- a/src/components/override-sdk/field/RichText/index.tsx
+++ b/src/components/override-sdk/field/RichText/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RichText';

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -1,6 +1,5 @@
 import React, { createElement, useEffect, useContext, useState } from 'react';
 import createPConnectComponent from '@pega/react-sdk-components/lib/bridge/react_pconnect';
-import ParsedHTML from '../../../helpers/formatters/ParsedHtml';
 import useIsOnlyField, {
   registerNonEditableField
 } from '../../../helpers/hooks/QuestionDisplayHooks';
@@ -13,15 +12,12 @@ import { useTranslation } from 'react-i18next';
 
 export default function DefaultForm(props) {
   const { getPConnect, readOnly, additionalProps, configAlternateDesignSystem } = props;
-
   const { hasBeenWrapped } = useContext(ReadOnlyDefaultFormContext);
-  const { DFName } = useContext(DefaultFormContext);
   const { instructionText: passedThroughInstructionText } = useContext(DefaultFormContext);
   const { t } = useTranslation();
 
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
 
-  const [declaration, setDeclaration] = useState({ text1: '', warning1: '' });
   let containerName = null;
   if (getPConnect().getDataObject().caseInfo?.assignments) {
     containerName = getPConnect().getDataObject().caseInfo?.assignments[0].name;
@@ -122,36 +118,6 @@ export default function DefaultForm(props) {
         isArrayDeepMerge: false
       }
     });
-  }, []);
-
-  useEffect(() => {
-    if (containerName === 'Declaration') {
-      // Get current context
-      const context = PCore.getContainerUtils().getActiveContainerItemName(
-        `${PCore.getConstants().APP.APP}/primary`
-      );
-      // Get is documentation required flag value
-      const isDocumentationRequired = PCore.getStoreValue(
-        '.IsDocumentationRequired',
-        'context_data.caseInfo.content.Claim.summary_of_when_conditions__',
-        context
-      );
-
-      if (isDocumentationRequired) {
-        const declarationText1 = PCore.getStoreValue(
-          '.DeclarationText1',
-          'caseInfo.content.Claim',
-          context
-        );
-        const declarationWarning1 = PCore.getStoreValue(
-          '.DeclarationWarning1',
-          'caseInfo.content.Claim',
-          context
-        );
-
-        setDeclaration({ text1: declarationText1, warning1: declarationWarning1 });
-      }
-    }
   }, []);
 
   const dfChildren = arChildren?.map((kid, idx) => {
@@ -258,11 +224,6 @@ export default function DefaultForm(props) {
           {instructionExists && !singleQuestionPage && (
             <InstructionTextComponent instructionText={instructionText} />
           )}
-          {declaration.text1 && DFName === -1 && (
-            <div id='declarationText1' className='govuk-body'>
-              <ParsedHTML htmlString={declaration.text1} />
-            </div>
-          )}
           {cssClassHook === 'u-childRemove' ? (
             <>
               {dfChildren[0]}
@@ -270,11 +231,6 @@ export default function DefaultForm(props) {
             </>
           ) : (
             <>{dfChildren}</>
-          )}
-          {declaration.warning1 && DFName === -1 && (
-            <div id='declarationWarning1' className='govuk-body'>
-              <ParsedHTML htmlString={declaration.warning1} />
-            </div>
           )}
         </DefaultFormContext.Provider>
       }


### PR DESCRIPTION
The bug is on the declaration screen. We have duplicate declaration text and warning (if the user has to send in documents i.e. adoption or born in another country).

Pega is using RichText fields for this content. Previously we were using the redux store to display these values in the correct place and with the correct styles I have removed this old code. 

Also the standard RichText pega component adds a lot of nesting to the text, and also a blank label tag, which isn't accessible.

So in this code I've created an override component for RichText which very simply passes the value (html) to the ParsedHtml component so it's displayed correctly. I've also added a check for a 'p' tag and if so add the 'govuk-body' class to the surrounding div so it has the correct styles.  