### PR TITLE
BUG-7400 autocomplete in address field fix

### DIFF
--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -194,7 +194,9 @@ export default function AutoComplete(props: AutoCompleteProps) {
 
   useEffect(() => {
     const element = document.getElementById(formattedPropertyName) as HTMLInputElement;
-    const elementUl = document.getElementById(`${name}__listbox`) as HTMLInputElement;
+    const elementUl = document.getElementById(
+      `${formattedPropertyName}__listbox`
+    ) as HTMLInputElement;
 
     if (validatemessage) {
       element?.classList.add('govuk-input--error');

--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -70,7 +70,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
     displayOrder,
     name
   } = props;
-  
+
   const localizedVal = PCore.getLocaleUtils().getLocaleValue;
   const [errorMessage, setErrorMessage] = useState(localizedVal(validatemessage));
   const [isAutocompleteLoaded, setAutocompleteLoaded] = useState(false);
@@ -193,7 +193,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
   };
 
   useEffect(() => {
-    const element = document.getElementById(name) as HTMLInputElement;
+    const element = document.getElementById(formattedPropertyName) as HTMLInputElement;
     const elementUl = document.getElementById(`${name}__listbox`) as HTMLInputElement;
 
     if (validatemessage) {


### PR DESCRIPTION
The handlechange event of autocomplete was not working as expected when wrapped in main wrapper from pega. Because it was not able to get the id of autocomplete component. This fix is to address the issue