### PR TITLE
Bug 8375 - Error summary not showing autocomplete field errors. 

### DIFF
--- a/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
+++ b/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
@@ -52,6 +52,11 @@ export default function AutoComplete(props) {
       );
     });
 
+  useEffect(() => {
+    // Publish event so that errorSummary component can be updated with autocomplete field errors after rendering.
+    PCore.getPubSubUtils().publish('autoCompleteFieldPresent', { error: errorText });
+  }, [optionList, errorText]);
+
   const getDefaultValue = () => {
     return optionList.forEach(item => {
       if (item.key === selectedValue) {

--- a/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
+++ b/src/components/BaseComponents/Autocomplete/Autocomplete.tsx
@@ -38,6 +38,9 @@ export default function AutoComplete(props) {
         selectElement: document.getElementById(id),
         defaultValue: ''
       });
+
+      // Publish event so that errorSummary component can be updated with autocomplete field errors after rendering.
+      PCore.getPubSubUtils().publish('autoCompleteFieldPresent', { error: errorText });
     }
   }, [optionList]);
   const arrOptions =
@@ -51,11 +54,6 @@ export default function AutoComplete(props) {
         </option>
       );
     });
-
-  useEffect(() => {
-    // Publish event so that errorSummary component can be updated with autocomplete field errors after rendering.
-    PCore.getPubSubUtils().publish('autoCompleteFieldPresent', { error: errorText });
-  }, [optionList, errorText]);
 
   const getDefaultValue = () => {
     return optionList.forEach(item => {


### PR DESCRIPTION
Currently the error summary component is missing the error(s) from any autocomplete fields as the error summary component hasn't re-rendered before the error checking has completed. I've added a publish event which we can subscribe to in the assignment component so that we can update the errors in the error summary once the re-render (and loading of the options list) is complete. 