### PR TITLE
Bug 8232 - Language toggle issue#R

### DIFF
--- a/src/components/AppComponents/LanguageToggle/index.tsx
+++ b/src/components/AppComponents/LanguageToggle/index.tsx
@@ -21,6 +21,7 @@ const LanguageToggle = props => {
       PCore.getLocaleUtils().loadLocaleResources([
         PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
         '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE',
+        '@BASECLASS!DATAPAGE!D_SCOPEDREFERENCEDATALISTBYTYPE',
         'HMRC-CHB-WORK-CLAIM!CASE!CLAIM'
       ]);
 


### PR DESCRIPTION
**_BUG-8232 -Language toggle issue#R_**

This issue is about the radio option is not getting translated when we toggle language to Welsh.

The issue is, the radio option content was present in the D_SCOPEDREFERENCEDATALISTBYTYPE.json but this json is not been called on loadlocalereferences of the toggle action. 

Now we have added this json in toggle action.(also verified this json was referred as datapage as table type in the assign worklist json response.)