### PR TITLE
Reverts Language toggle 'set up' for HICBC claims and adds sdk config 'approach' to toggle back on in future

### DIFF
--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect } from 'react';
+import React, { FunctionComponent, useState, useEffect, useContext } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
@@ -19,6 +19,7 @@ import { getSdkConfig } from '@pega/auth/lib/sdk-auth-manager';
 import useHMRCExternalLinks from '../../components/helpers/hooks/HMRCExternalLinks';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
 import { triggerLogout } from '../../components/helpers/utils';
+import AppContext from './reuseables/AppContext';
 
 // declare const myLoadMashup;
 
@@ -27,6 +28,8 @@ const ClaimPage: FunctionComponent<any> = () => {
     const [shutterServicePage, /* setShutterServicePage */] = useState(false);
     const [serviceNotAvailable, /* setServiceNotAvailable */] = useState(false);
     const [pCoreReady, setPCoreReady] = useState(false);
+    const {showLanguageToggle} = useContext(AppContext);
+
     const setAuthType = useState('gg')[1];
 
     const [currentDisplay, setCurrentDisplay] = useState<|'pegapage'|'resolutionpage'|'servicenotavailable'|'shutterpage'|'loading'>('pegapage');
@@ -45,8 +48,10 @@ const ClaimPage: FunctionComponent<any> = () => {
     const { hmrcURL } = useHMRCExternalLinks();
 
     useEffect(() => 
-        {initTimeout(setShowTimeoutModal, false, true, false) }
-    , []);
+        {
+          initTimeout(setShowTimeoutModal, false, true, false)         
+        }        
+    , []);    
     
     function doRedirectDone() {
         history.push('/hicbc/opt-in');
@@ -196,7 +201,7 @@ const ClaimPage: FunctionComponent<any> = () => {
       <AppHeader
         handleSignout={handleSignout}
         appname={t('HIGH_INCOME_BENEFITS')}
-        hasLanguageToggle
+        hasLanguageToggle={showLanguageToggle}
         isPegaApp={showPega}
         languageToggleCallback={
           () => {} /* toggleNotificationProcess(

--- a/src/samples/HighIncomeCase/LandingPage.tsx
+++ b/src/samples/HighIncomeCase/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import  MainWrapper   from '../../components/BaseComponents/MainWrapper';
 import  RadioButtons  from '../../components/BaseComponents/RadioButtons/RadioButtons';
@@ -8,13 +8,15 @@ import AppHeader from './reuseables/AppHeader';
 import AppFooter from '../../components/AppComponents/AppFooter';
 import useHMRCExternalLinks from '../../components/helpers/hooks/HMRCExternalLinks';
 import setPageTitle from '../../components/helpers/setPageTitleHelpers';
+import AppContext from './reuseables/AppContext';
 
 export default function LandingPage(props){
     const {onProceedHandler} = props;    
     const beforeOptionValue = 'before6April';     
     const onOrAfterOptionValue = 'onOrAfter6April'; 
     const [errorText, setErrorText] = useState('');
-    const [selectedOption, setSelectedOption] = useState();  
+    const [selectedOption, setSelectedOption] = useState(); 
+    const {showLanguageToggle} = useContext(AppContext); 
 
     const { hmrcURL } = useHMRCExternalLinks();
 
@@ -44,7 +46,7 @@ export default function LandingPage(props){
         <>
             <AppHeader
                 appname={t('HIGH_INCOME_BENEFITS')}
-                hasLanguageToggle
+                hasLanguageToggle={showLanguageToggle}
                 betafeedbackurl={`${hmrcURL}contact/beta-feedback?service=463&referrerUrl=${window.location}`}                  
             />
             <div className='govuk-width-container'>                

--- a/src/samples/HighIncomeCase/index.tsx
+++ b/src/samples/HighIncomeCase/index.tsx
@@ -13,7 +13,8 @@ const HighIncomeCase: FunctionComponent<any> = () => {
   const [showLandingPage, setShowLandingPage] = useState<boolean>(
     !window.location.search.includes('code')
   );
-  const [shuttered, setShuttered] = useState(null);
+  const [shuttered, setShuttered] = useState(null);  
+  const [showLanguageToggle, setShowLanguageToggle] = useState(false);
 
   const { t } = useTranslation();
   registerServiceName(t('HIGH_INCOME_BENEFITS'));
@@ -25,6 +26,11 @@ const HighIncomeCase: FunctionComponent<any> = () => {
   const toggleShowLandingPageTrue = () => {
     setShowLandingPage(true);
   };
+  useEffect(() => {
+    getSdkConfig().then((config)=>{
+      setShowLanguageToggle(config?.hicbcOptinConfig?.showLanguageToggle);
+    })
+  }, [])
 
   useEffect(() => {
     getSdkConfig().then(config => {
@@ -62,7 +68,7 @@ const HighIncomeCase: FunctionComponent<any> = () => {
   } else {
     return (
       <AppContext.Provider
-        value={{ appBacklinkProps: { appBacklinkAction: toggleShowLandingPageTrue } }}
+        value={{ appBacklinkProps: { appBacklinkAction: toggleShowLandingPageTrue }, showLanguageToggle: showLanguageToggle}}
       >
         {showLandingPage ? (
           <LandingPage onProceedHandler={() => landingPageProceedHandler()} />

--- a/src/samples/HighIncomeCase/reuseables/AppContext.ts
+++ b/src/samples/HighIncomeCase/reuseables/AppContext.ts
@@ -6,7 +6,8 @@ export interface AppContextValues {
     appBacklinkProps:{
         appBacklinkAction?:Function,
         appBacklinkText?:String
-    }
+    },
+    showLanguageToggle?: boolean
 }
 
 const AppContext =  createContext<AppContextValues>(
@@ -14,7 +15,8 @@ const AppContext =  createContext<AppContextValues>(
                                     appBacklinkProps:{
                                         appBacklinkAction: null,
                                         appBacklinkText: null  
-                                    }                                  
+                                    },
+                                    showLanguageToggle: false
                                 });
 
 export { AppContext as default }


### PR DESCRIPTION
Reverts 'enabling' of Language toggle for HICBC claim as we are not yet ready for translations.

Adds handling of a SDK-config item for future toggling on/off of the feature. (Will remained toggled off if the SDK config item is not present)