### PR TITLE
Fix required to ensure integrated DXCB can continue to build and publish custom/overriden DX components

### DIFF
--- a/constellation-comp-config/tsconfig.build.json
+++ b/constellation-comp-config/tsconfig.build.json
@@ -7,7 +7,8 @@
     "../src/components/custom-constellation/**/**/*.jsx",
     "../src/components/helpers/formatters/ParsedHtml.tsx",
     "../src/components/helpers/hooks/QuestionDisplayHooks.ts",
-    "../src/components/helpers/HMRCAppContext.tsx"
+    "../src/components/helpers/HMRCAppContext.tsx",
+    "../src/samples/HighIncomeCase/reuseables/AppContext.ts"
     // "../src/components/override-sdk/**/**/*.ts",
     // "../src/components/override-sdk/**/**/*.tsx",
     // "../src/components/override-sdk/**/**/*.js",

--- a/src/samples/HighIncomeCase/reuseables/AppContext.ts
+++ b/src/samples/HighIncomeCase/reuseables/AppContext.ts
@@ -1,22 +1,19 @@
-
 import { createContext } from 'react';
 
-
 export interface AppContextValues {
-    appBacklinkProps:{
-        appBacklinkAction?:Function,
-        appBacklinkText?:String
-    },
-    showLanguageToggle?: boolean
+  appBacklinkProps: {
+    appBacklinkAction?: Function | null;
+    appBacklinkText?: String | null;
+  };
+  showLanguageToggle?: boolean;
 }
 
-const AppContext =  createContext<AppContextValues>(
-                                {
-                                    appBacklinkProps:{
-                                        appBacklinkAction: null,
-                                        appBacklinkText: null  
-                                    },
-                                    showLanguageToggle: false
-                                });
+const AppContext = createContext<AppContextValues>({
+  appBacklinkProps: {
+    appBacklinkAction: null,
+    appBacklinkText: null
+  },
+  showLanguageToggle: false
+});
 
-export { AppContext as default }
+export { AppContext as default };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,7 +5,8 @@
     "./src/components/**/*.tsx",
     "./src/components/**/*.js",
     "./src/components/**/*.jsx",
-    "./node_modules/react-i18next/dist/commonjs/index.js"
+    "./node_modules/react-i18next/dist/commonjs/index.js",
+    "./src/samples/HighIncomeCase/reuseables/AppContext.ts"
   ],
   "exclude": [
     "./src/**/*.stories.ts",


### PR DESCRIPTION
Added required HICBC AppContext file to tsconfig files and fixed a minor TypeScript issue in the file to allow for DXCB build and publish of custom/overriden DX components.