### PR TITLE
US-13377 : Addressing BA review comments for welsh content for error heading

### DIFF
--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -269,7 +269,8 @@ export default function ChildBenefitsClaim() {
     PCore.getPubSubUtils().subscribe(
       'assignmentFinished',
       () => {
-        if (!assignmentFinishedFlag) { // Temporary workaround to restrict infinite update calls
+        if (!assignmentFinishedFlag) {
+          // Temporary workaround to restrict infinite update calls
           setShowStartPage(false);
           setShowUserPortal(false);
           setShowPega(false);
@@ -284,7 +285,7 @@ export default function ChildBenefitsClaim() {
             displayServiceNotAvailable();
 
             PCore.getContainerUtils().closeContainerItem(context);
-            //Temporary workaround to restrict infinite update calls
+            //  Temporary workaround to restrict infinite update calls
             assignmentFinishedFlag = true;
             PCore?.getPubSubUtils().unsubscribe(
               PCore.getConstants().PUB_SUB_EVENTS.CASE_EVENTS.END_OF_ASSIGNMENT_PROCESSING,

--- a/src/samples/StaticPages/ErrorSummary/index.tsx
+++ b/src/samples/StaticPages/ErrorSummary/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 
 export default function StaticPageErrorSummary({ errorSummary, linkHref }) {
+  const { t } = useTranslation();
   return (
     <>
       <>
         {errorSummary && errorSummary.length > 0 ? (
           <div className='govuk-error-summary' data-module='govuk-error-summary' tabIndex={-1}>
             <div role='alert'>
-              <h2 className='govuk-error-summary__title'>There is a problem</h2>
+              <h2 className='govuk-error-summary__title'>{t('THERE_IS_A_PROBLEM')}</h2>
               <div className='govuk-error-summary__body'>
                 <ul className='govuk-list govuk-error-summary__list'>
                   <li key='error-summary'>


### PR DESCRIPTION
As a part of this PR we have fixed the issue around the heading of the error at summary level of static pages.

Before we are not getting welsh content , so now we are getting welsh upon clicking choice of welsh at top of the page.