### PR TITLE
Bug-8588 : Issue around reference number on confirmation page

### DIFF
--- a/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
+++ b/src/samples/ChildBenefitsClaim/ConfirmationPage.tsx
@@ -24,7 +24,7 @@ const ConfirmationPage = ({ caseId, caseStatus, isUnAuth }) => {
   const chbOfficeLink = 'https://www.gov.uk/child-benefit-tax-charge/your-circumstances-change';
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
   const sessionCaseId =
-    (sessionStorage.getItem('isNinoPresent') && sessionStorage.getItem('caseRefId')) || '';
+    (!sessionStorage.getItem('isNinoPresent') && sessionStorage.getItem('caseRefId')) || '';
   const referenceNumber = refId || sessionCaseId?.replace('HMRC-CHB-WORK ', '');
 
   function getFeedBackLink() {


### PR DESCRIPTION
This PR fixes the issues around appearing of reference number on confirmation page even if claimant entered NINO.

Also it fixes the issue where after reload of confirmation page , claimant is seeing reference number for NINO provided.