### PR TITLE
US-13973 Updated the date format in CYA screen

### DIFF
--- a/src/components/override-sdk/field/Date/Date.tsx
+++ b/src/components/override-sdk/field/Date/Date.tsx
@@ -10,6 +10,7 @@ import { GBdate, checkStatus } from '../../../helpers/utils';
 import handleEvent from '@pega/react-sdk-components/lib/components/helpers/event-utils';
 import GDSCheckAnswers from '../../../BaseComponents/CheckAnswer/index';
 import { ReadOnlyDefaultFormContext } from '../../../helpers/HMRCAppContext';
+import dayjs from 'dayjs';
 
 declare const global;
 
@@ -147,7 +148,7 @@ export default function Date(props) {
     );
   }
   if (readOnly) {
-    return <ReadOnlyDisplay label={label} value={new global.Date(value).toLocaleDateString()} />;
+    return <ReadOnlyDisplay label={label} value={dayjs(value).format('D MMMM YYYY')} />;
   }
 
   const extraProps = { testProps: { 'data-test-id': testId } };


### PR DESCRIPTION
 date from the CYA screen will be displayed to the customer in the following format: d month yyyy (Ex: 6 May 2024)
![image](https://github.com/norm-l/odx/assets/124593991/851e9995-6ca4-412e-affa-6e724c3680f5)
