### PR TITLE
Bug-8770-8771 : Empty h2 elements are being rendered on multiple pages

### DIFF
--- a/src/components/custom-sdk/template/HMRC_ODX_GDSSummaryCard/index.tsx
+++ b/src/components/custom-sdk/template/HMRC_ODX_GDSSummaryCard/index.tsx
@@ -106,7 +106,7 @@ export default function HmrcOdxGdsSummaryCard(props) {
 
   return (
     <StyledHmrcOdxGdsSummaryCardWrapper>
-      <h2>{sectionHeader}</h2>
+      {sectionHeader && <h2>{sectionHeader}</h2>}
       <Grid
         container={{
           cols: `repeat(${nCols}, minmax(0, 1fr))`,
@@ -115,7 +115,7 @@ export default function HmrcOdxGdsSummaryCard(props) {
       >
         <div className='govuk-summary-card'>
           <div className='govuk-summary-card__title-wrapper'>
-            <h2 className='govuk-summary-card__title'>{itemName}</h2>
+            {itemName && <h2 className='govuk-summary-card__title'>{itemName}</h2>}
             <ul className='govuk-summary-card__actions'>
               {!isSingleEntity(pageReference, getPConnect) && (
                 <li className='govuk-summary-card__action remove-link'>

--- a/src/components/override-sdk/infra/View/View.tsx
+++ b/src/components/override-sdk/infra/View/View.tsx
@@ -34,7 +34,7 @@ export default function View(props) {
   // call the locale reference api when we toggle the languge from English to Welsh
   useEffect(() => {
     PCore.getPubSubUtils().subscribe('languageToggleTriggered', locale => {
-      if(!locale.localeRef.includes(props.localeReference)) {
+      if (!locale.localeRef.includes(props.localeReference)) {
         locale.localeRef.push(props.localeReference);
         PCore.getLocaleUtils().loadLocaleResources([props.localeReference]);
       }
@@ -98,7 +98,7 @@ export default function View(props) {
 
     return (
       <>
-        {showLabel && !NO_HEADER_TEMPLATES.includes(template) && (
+        {showLabel && !NO_HEADER_TEMPLATES.includes(template) && label && label !== ' ' && (
           <h2 className='govuk-heading-m'>{label}</h2>
         )}
         {RenderedTemplate}


### PR DESCRIPTION
As a part of this PR we have fixed an accessibility issue where empty html h2 elements are being rendered on multiple pages.

