### PR TITLE
Bug 8785 Timeout counter - 0 Sec not counted

### DIFF
--- a/src/components/AppComponents/TimeoutPopup/index.tsx
+++ b/src/components/AppComponents/TimeoutPopup/index.tsx
@@ -95,6 +95,18 @@ export default function TimeoutPopup(props) {
   }, [timeoutState.timeRemaining]);
 
   useEffect(() => {
+    if (isAuthorised && timeoutState.timeRemaining === 0) {
+      const signoutHandlerTimeout = setTimeout(() => {
+        signoutHandler();
+      }, 1000);
+
+      return () => {
+        clearTimeout(signoutHandlerTimeout);
+      };
+    }
+  }, [isAuthorised, timeoutState.timeRemaining]);
+
+  useEffect(() => {
     if (show) {
       window.addEventListener('keydown', staySignedInCallback);
     } else {

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -49,9 +49,6 @@ function initTimeout(setShowTimeoutModal) {
 
   applicationTimeout = setTimeout(() => {
     setShowTimeoutModal(true);
-    signoutTimeout = setTimeout(() => {
-      triggerLogout();
-    }, milisecondsTilSignout);
   }, milisecondsTilWarning);
 }
 

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -37,7 +37,6 @@ declare const myLoadMashup: any;
 
 /* Time out modal functionality */
 let applicationTimeout = null;
-let signoutTimeout = null;
 // Sets default timeouts (13 mins for warning, 115 seconds for sign out after warning shows)
 let milisecondsTilSignout = 115 * 1000;
 let milisecondsTilWarning = 780 * 1000;
@@ -45,7 +44,6 @@ let milisecondsTilWarning = 780 * 1000;
 // Clears any existing timeouts and starts the timeout for warning, after set time shows the modal and starts signout timer
 function initTimeout(setShowTimeoutModal) {
   clearTimeout(applicationTimeout);
-  clearTimeout(signoutTimeout);
 
   applicationTimeout = setTimeout(() => {
     setShowTimeoutModal(true);


### PR DESCRIPTION
The bug is that the countdown timer doesn't reach '0' before sign out on the declaration screen. By using the 'signoutHandler' to sign out after the countdown is completed you can now see '0' in the countdown before the app signs out. I've also removed the 'signoutTimeout' functionality as this isn't being used anymore.  