### PR TITLE
Translatable Summary Pages and Instruction Text 

### DIFF
--- a/src/components/AppComponents/SummaryPage/SummaryPage.tsx
+++ b/src/components/AppComponents/SummaryPage/SummaryPage.tsx
@@ -24,7 +24,7 @@ export default function SummaryPage(props){
                         {summaryTitle}
                     </h1>
             }
-            <ParsedHTML htmlString={summaryContent} />
+            <div><ParsedHTML htmlString={summaryContent} /></div>
         </MainWrapper>
     </>
 }

--- a/src/components/override-sdk/template/SimpleTableManual/SimpleTableManual.tsx
+++ b/src/components/override-sdk/template/SimpleTableManual/SimpleTableManual.tsx
@@ -1,11 +1,15 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import { PConnProps } from '@pega/react-sdk-components/lib/types/PConnProps';
+import { registerNonEditableField } from '../../../helpers/hooks/QuestionDisplayHooks';
+import InstructionComp from '../../../helpers/formatters/ParsedHtml';
+
 
 interface SimpleTableManualProps extends PConnProps {
   referenceList?: [any];
   label?: string;
   showLabel?: boolean;
   propertyLabel?: string;
+  authorContext?: string;
 }
 
 export default function SimpleTableManual(props: PropsWithChildren<SimpleTableManualProps>) {
@@ -25,6 +29,19 @@ export default function SimpleTableManual(props: PropsWithChildren<SimpleTableMa
   }
 
   const headingList = children[0].children.map(child => child.config.label);
+
+  const [currentLang, setCurrentLang] = useState(sessionStorage.getItem('rsdk_locale')?.substring(0, 2).toUpperCase() || 'EN',);
+  useEffect(() => {
+    const subId = `scalarList_${label}`;
+    PCore.getPubSubUtils().subscribe('languageToggleTriggered', ({language}) => {
+      setCurrentLang(language.toUpperCase());
+    }, subId,)
+  }, [])
+
+  if(props.authorContext === '.ScreenContent.LocalisedContent'){
+    registerNonEditableField();
+    return <InstructionComp htmlString={referenceList.find(element => element.Language === currentLang.toUpperCase()).Content} />
+  }
 
   const renderTh = list => {
     return (

--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -23,6 +23,7 @@ import AppContext from './reuseables/AppContext';
 import toggleNotificationProcess from '../../components/helpers/toggleNotificationLanguage';
 
 // declare const myLoadMashup;
+declare const PCore:any;
 
 const ClaimPage: FunctionComponent<any> = () => {
     // const [bShowPega, setShowPega] = useState(false);
@@ -34,7 +35,8 @@ const ClaimPage: FunctionComponent<any> = () => {
     const setAuthType = useState('gg')[1];
 
     const [currentDisplay, setCurrentDisplay] = useState<|'pegapage'|'resolutionpage'|'servicenotavailable'|'shutterpage'|'loading'>('pegapage');
-    const [summaryPageContent, setSummaryPageContent] = useState<{content:string|null, title:string|null, banner:string|null}>({content:null, title:null, banner:null})
+    // Holds relevant summary page content (specific language)
+    const [summaryPageContent, setSummaryPageContent] = useState<any>({content:null, title:null, banner:null})    
     const { t } = useTranslation();
     
     const history = useHistory();
@@ -73,17 +75,22 @@ const ClaimPage: FunctionComponent<any> = () => {
               withoutDefaultHeaders: false,
             },
             '')
-            .then((response) => {
-              const summaryData = response.data.data.caseInfo.content;
-              setSummaryPageContent({content:summaryData.SubmissionContent, title:summaryData.SubmissionTitle, banner:summaryData.SubmissionBanner})
-            })
-            .catch(() => {                            
-              return false;
-            });
-        }
+            .then((response) => {     
+              PCore.getPubSubUtils().unsubscribe('languageToggleTriggered', 'summarypageLanguageChange');
+              const summaryData:Array<any> = response.data.data.caseInfo.content.ScreenContent.LocalisedContent;
+              /* const summaryData={
+                en:{content:'English content', title: 'English Title', banner:null},
+                cy:{content:'Welsh content', banner: 'Welsh Banner', title:null},
+              } */
+              // setSummaryPageData(summaryData);            
 
-        )
-      }
+              setSummaryPageContent(summaryData.find(data => data.Language === sessionStorage.getItem('rsdk_locale')?.slice(0,2).toUpperCase() || 'EN'));                              
+
+              PCore.getPubSubUtils().subscribe('languageToggleTriggered', ({language}) => {
+                setSummaryPageContent(summaryData.find(data => data.Language === language.toUpperCase()));             
+              }, 'summarypageLanguageChange');
+            })
+      })}
       else if(shutterServicePage){setCurrentDisplay('shutterpage')}      
       else if(serviceNotAvailable){setCurrentDisplay('servicenotavailable')}
       else {
@@ -217,9 +224,9 @@ const ClaimPage: FunctionComponent<any> = () => {
             </div>
             { serviceNotAvailable && <ServiceNotAvailable /> }            
             { currentDisplay === 'resolutionpage' && <SummaryPage summaryContent={
-              summaryPageContent.content}
-              summaryTitle={summaryPageContent.title}
-              summaryBanner={summaryPageContent.banner}
+              summaryPageContent.Content}
+              summaryTitle={summaryPageContent.Title}
+              summaryBanner={summaryPageContent.Banner}
               backlinkProps={{}}  
             />}        
           </>

--- a/src/samples/HighIncomeCase/ClaimPage.tsx
+++ b/src/samples/HighIncomeCase/ClaimPage.tsx
@@ -82,9 +82,10 @@ const ClaimPage: FunctionComponent<any> = () => {
                 en:{content:'English content', title: 'English Title', banner:null},
                 cy:{content:'Welsh content', banner: 'Welsh Banner', title:null},
               } */
-              // setSummaryPageData(summaryData);            
+              // setSummaryPageData(summaryData); 
+              const currentLang = sessionStorage.getItem('rsdk_locale')?.slice(0,2).toUpperCase() || 'EN';
 
-              setSummaryPageContent(summaryData.find(data => data.Language === sessionStorage.getItem('rsdk_locale')?.slice(0,2).toUpperCase() || 'EN'));                              
+              setSummaryPageContent(summaryData.find(data => data.Language === currentLang));                              
 
               PCore.getPubSubUtils().subscribe('languageToggleTriggered', ({language}) => {
                 setSummaryPageContent(summaryData.find(data => data.Language === language.toUpperCase()));             


### PR DESCRIPTION
Extends SimpleList component to handle 'special case' of Instruction text, driven by the content value (which should be standardised on Pega side)

Extends logic for fetching SummaryPage content, and to switch between different language content.