### PR TITLE
US-14729 - Read only dates in long format reflect selected user language

### DIFF
--- a/src/components/AppComponents/LanguageToggle/index.tsx
+++ b/src/components/AppComponents/LanguageToggle/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+require('dayjs/locale/cy');
 
 declare const PCore: any;
 
@@ -14,6 +16,7 @@ const LanguageToggle = props => {
     lang = e.currentTarget.getAttribute('lang');
     setSelectedLang(lang);
     sessionStorage.setItem('rsdk_locale', `${lang}_GB`);
+    dayjs.locale(lang);
     i18n.changeLanguage(lang);
     if (typeof PCore !== 'undefined') {
       PCore.getEnvironmentInfo().setLocale(`${lang}_GB`);
@@ -31,6 +34,18 @@ const LanguageToggle = props => {
       languageToggleCallback(lang);
     }
   };
+
+
+  // Initialises language value in session storage, and for dayjs
+  useEffect(() => {
+    if(!sessionStorage.getItem('rsdk_locale')){
+      sessionStorage.setItem('rsdk_locale', `en_GB`);
+      dayjs.locale('en');
+    } else {
+      const currentLang = sessionStorage.getItem('rsdk_locale').slice(0,2).toLowerCase();
+      dayjs.locale(currentLang);
+    }
+  }, [])
 
   useEffect(() => {
     document.documentElement.lang = selectedLang;

--- a/src/components/override-sdk/field/Date/Date.tsx
+++ b/src/components/override-sdk/field/Date/Date.tsx
@@ -132,7 +132,7 @@ export default function Date(props) {
     return (
       <GDSCheckAnswers
         label={props.label}
-        value={new global.Date(value).toLocaleDateString()}
+        value={dayjs(value).format('D MMMM YYYY')}
         name={name}
         stepId={configAlternateDesignSystem.stepId}
         getPConnect={getPConnect}


### PR DESCRIPTION
Updates date component with an inline change link to display long form date format  (e.g '4 March 2024')
Also hooks dayjs into language change logic to ensure that that long form date display reflects current selected language.