### PR TITLE
BUG-8839 - E-mail & TxtMsg contents are not showing in welsh

### DIFF
--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -24,6 +24,7 @@ import StoreContext from '@pega/react-sdk-components/lib/bridge/Context/StoreCon
 import AppContextEducation from '../../../../samples/EducationStart/reuseables/AppContextEducation'; // TODO: Once this code exposed to common folder, we will remove this import from EducationStart
 import AppContext from '../../../../samples/HighIncomeCase/reuseables/AppContext';
 import dayjs from 'dayjs';
+import toggleNotificationProcess from '../../../../components/helpers/toggleNotificationLanguage';
 
 export interface ErrorMessageDetails {
   message: string;
@@ -95,6 +96,18 @@ export default function Assignment(props) {
   useEffect(() => {
     setServiceShutteredStatus(serviceShuttered);
   }, [serviceShuttered]);
+
+  // Sets the language for the texts and emails if the user changes the language before opening an existing claim.
+  useEffect(() => {
+    const currentLanguage = sessionStorage.getItem('rsdk_locale')?.substring(0, 2);
+
+    const setLangauge = toggleNotificationProcess(
+      { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
+      thePConn
+    );
+
+    setLangauge(currentLanguage);
+  }, []);
 
   useEffect(() => {
     const updateErrorTimeOut = setTimeout(() => {


### PR DESCRIPTION
I've added the toggleNotificationProcess so that when a user starts or opens an existing claim it runs once and sets the language for the emails and texts. This means if a user starts a claim in English, saves it for later, then changes the language to Welsh for example, then finishes the claim the text and email will be in Welsh. 