### PR TITLE
BUG-8933 fix

### DIFF
--- a/src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/index.tsx
+++ b/src/components/custom-sdk/template/HMRC_ODX_GDSTaskListTemplate/index.tsx
@@ -104,11 +104,11 @@ export default function HmrcOdxGdsTaskListTemplate(props: HmrcOdxGdsTaskListTemp
         {children[0]}
       </Grid>
       <div className='govuk-!-padding-bottom-4'>
-        <p className='govuk-body govuk-!-font-weight-bold'>
+        <h2 className='govuk-heading-s'>
           {completedSections < totalSections
             ? `${t('CLAIM')} ${t('INCOMPLETE')}`
             : `${t('CLAIM')} ${t('COMPLETE')}`}
-        </p>
+        </h2>
         <p className='govuk-body govuk-!-padding-bottom-4'>
           {`${t('YOU_HAVE_COMPLETED')} ${completedSections} ${t('OF')} ${totalSections} ${t(
             'SECTIONS'


### PR DESCRIPTION
Visually styled headings which introduce new sections of content to the page have not been marked up programmatically for screen reader users. This may be problematic for screen reader users who use headings to identify and navigate different sections of content on the page and would expect visually styled headings to be marked up programmatically using headings as part of the heading structure on the page.

 