### PR TITLE
US-14920 - View PoE page and ChB Hub - Time out

### DIFF
--- a/assets/i18n/cy.json
+++ b/assets/i18n/cy.json
@@ -384,6 +384,8 @@
   "CHB_HOMEPAGE_HICBC_CHARGE_LINK": "Tâl Treth Budd-dal Plant Incwm Uchel",
 
   "CHILD_BENEFIT": "Budd-dal Plant",
+  
+  "TRY_AGAIN_LATER": "Rhowch gynnig arall arni yn nes ymlaen.",
 
   "NO_AWARD_HEADING": "Nid ydych yn hawlio Budd-dal Plant",
   "NO_AWARD_CANNOT_FIND_CLAIM": "Ni allwn ddod o hyd i hawliad am Fudd-dal Plant ar eich cyfer.",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -389,6 +389,8 @@
   "NO_AWARD_NO_LONGER_RECEIVING_BENEFIT":"you no longer receive Child Benefit",
   "NO_AWARD_YOU_CAN":"You can",
   "NO_AWARD_FIND_OUT_MORE_LINKTEXT":"find out more about Child Benefit",
+
+  "TRY_AGAIN_LATER": "Try again later.",
   
   "YOUNG_PERSON_NAME": "Young person name",
   "EDUCATION_PORTAL_WARNING_TEXT2": "and will store your information for 28 days.",

--- a/src/samples/ChildBenefitHub/ChildBenefitHub.tsx
+++ b/src/samples/ChildBenefitHub/ChildBenefitHub.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { loginIfNecessary, sdkIsLoggedIn } from '@pega/auth/lib/sdk-auth-manager';
 import AppHeader from '../../components/AppComponents/AppHeader';
@@ -8,9 +8,15 @@ import { registerServiceName } from '../../components/helpers/setPageTitleHelper
 import useHMRCExternalLinks from '../../components/helpers/hooks/HMRCExternalLinks';
 import { triggerLogout } from '../../components/helpers/utils';
 import { Link } from 'react-router-dom';
+import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
+import {
+  initTimeout,
+} from '../../components/AppComponents/TimeoutPopup/timeOutUtils';
+
 
 export default function ChildBenefitHub() {
   const history = useHistory();
+  const [showTimeoutModal, setShowTimeoutModal] = useState(false);
   const { t } = useTranslation();
   const { hmrcURL } = useHMRCExternalLinks();
 
@@ -20,6 +26,10 @@ export default function ChildBenefitHub() {
     // appName and mainRedirect params have to be same as earlier invocation
     loginIfNecessary({ appName: 'embedded', mainRedirect: true });
   };
+
+  useEffect(() => {        
+    initTimeout(setShowTimeoutModal, false, true, false)
+  }, [])
 
   useEffect(() => {
     if (!sdkIsLoggedIn()) {
@@ -39,6 +49,21 @@ export default function ChildBenefitHub() {
         appname={t('CHB_HOMEPAGE_HEADING')}
         handleSignout={handleSignout}
       />
+      <TimeoutPopup
+                show={showTimeoutModal}
+                staySignedinHandler={() =>
+                  {
+                    setShowTimeoutModal(false);
+                    initTimeout(setShowTimeoutModal, false, true, false);
+                    //Using operator details call as 'app agnostic' session keep-alive
+                    PCore.getUserApi().getOperatorDetails(PCore.getEnvironmentInfo().getOperatorIdentifier());
+                  }                 
+                }
+                signoutHandler={triggerLogout}
+                isAuthorised
+                signoutButtonText='Sign out'
+                staySignedInButtonText='Stay signed in'
+             />
       <div className='govuk-width-container'>
         <main className='govuk-main-wrapper govuk-main-wrapper--l' id='main-content' role='main'>
           <div className='govuk-grid-row'>

--- a/src/samples/ChildBenefitHub/ChildBenefitHub.tsx
+++ b/src/samples/ChildBenefitHub/ChildBenefitHub.tsx
@@ -55,7 +55,7 @@ export default function ChildBenefitHub() {
                   {
                     setShowTimeoutModal(false);
                     initTimeout(setShowTimeoutModal, false, true, false);
-                    //Using operator details call as 'app agnostic' session keep-alive
+                    // Using operator details call as 'app agnostic' session keep-alive
                     PCore.getUserApi().getOperatorDetails(PCore.getEnvironmentInfo().getOperatorIdentifier());
                   }                 
                 }

--- a/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
+++ b/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
@@ -11,6 +11,8 @@ import { registerServiceName } from '../../components/helpers/setPageTitleHelper
 import { triggerLogout } from '../../components/helpers/utils';
 import MainWrapper from '../../components/BaseComponents/MainWrapper';
 import Button from '../../components/BaseComponents/Button/Button';
+import TimeoutPopup from '../../components/AppComponents/TimeoutPopup';
+import {initTimeout} from '../../components/AppComponents/TimeoutPopup/timeOutUtils'
 
 declare const PCore;
 declare const myLoadMashup: any;
@@ -20,6 +22,7 @@ export default function ProofOfEntitlement(){
     const [entitlementData, setEntitlementData] = useState(null);
     const [showNoAward, setShowNoAward] = useState(false);    
     const [showProblemWithService, setShowProblemWithService] = useState(false);    
+    const [showTimeoutModal, setShowTimeoutModal] = useState(false);
     const history = useHistory();
     const {t} = useTranslation();
 
@@ -30,6 +33,10 @@ export default function ProofOfEntitlement(){
         // appName and mainRedirect params have to be same as earlier invocation
         loginIfNecessary({ appName: 'embedded', mainRedirect: true });   
     }
+
+    useEffect(() => {        
+        initTimeout(setShowTimeoutModal, false, true, false)
+    }, [])
 
     useEffect( () => {
         if(!sdkIsLoggedIn()){
@@ -64,6 +71,21 @@ export default function ProofOfEntitlement(){
     return (
         <>
             <AppHeader appname={t('CHB_HOMEPAGE_HEADING')} hasLanguageToggle handleSignout={sdkIsLoggedIn() ? triggerLogout : null} />
+            <TimeoutPopup
+                show={showTimeoutModal}
+                staySignedinHandler={() =>
+                    {
+                        setShowTimeoutModal(false);                        
+                        initTimeout(setShowTimeoutModal, false, true, false);
+                        //Using operator details call as 'app agnostic' session keep-alive
+                        PCore.getUserApi().getOperatorDetails(PCore.getEnvironmentInfo().getOperatorIdentifier());
+                    }                 
+                }
+                signoutHandler={triggerLogout}
+                isAuthorised
+                signoutButtonText='Sign out'
+                staySignedInButtonText='Stay signed in'
+             />
             {sdkIsLoggedIn() && 
             <div className='govuk-width-container'>
             <MainWrapper>
@@ -118,7 +140,7 @@ export default function ProofOfEntitlement(){
                             {
                                 showProblemWithService && <>
                                     <h1 className="govuk-heading-l">{t('SERVICE_NOT_AVAILABLE')}</h1>
-                                    <p className='govuk-body'>{t('COME_BACK_LATER')}</p>
+                                    <p className='govuk-body'>{t('TRY_AGAIN_LATER')}</p>
                                     <p className='govuk-body'>{t('YOU_WILL_NEED_TO_START_AGAIN')}</p>
                                 </>
                             }

--- a/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
+++ b/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
@@ -77,7 +77,7 @@ export default function ProofOfEntitlement(){
                     {
                         setShowTimeoutModal(false);                        
                         initTimeout(setShowTimeoutModal, false, true, false);
-                        //Using operator details call as 'app agnostic' session keep-alive
+                        // Using operator details call as 'app agnostic' session keep-alive
                         PCore.getUserApi().getOperatorDetails(PCore.getEnvironmentInfo().getOperatorIdentifier());
                     }                 
                 }


### PR DESCRIPTION
Add the timeout functionality to the 'View Proof Entitlement' and ChB Hub pages to ensure that users security is upheld but automatically logging them out after certain time of inactivity.

Reuses the existing Timeout component

However, have tried using 'PCore.getUserApi().getOperatorDetails(PCore.getEnvironmentInfo().getOperatorIdentifier());' as the service keep-alive. - This is to avoid using application specific data pages. This call appears to make an api call each time so expecting this will work reliably.