### PR TITLE
feat: US-14607 Portal Conditioning

### DIFF
--- a/src/components/AppComponents/SummaryPage/SummaryPage.tsx
+++ b/src/components/AppComponents/SummaryPage/SummaryPage.tsx
@@ -1,30 +1,40 @@
-import React, {useEffect} from 'react';
-import  MainWrapper from '../../BaseComponents/MainWrapper' ;
+import React, { useEffect, forwardRef } from 'react';
+import MainWrapper from '../../BaseComponents/MainWrapper';
 import Button from '../../BaseComponents/Button/Button';
 import ParsedHTML from '../../helpers/formatters/ParsedHtml';
 import setPageTitle from '../../helpers/setPageTitleHelpers';
 
-export default function SummaryPage(props){
-    const {summaryTitle, summaryContent, summaryBanner, backlinkProps} = props; 
-    const {backlinkAction, backlinkText} = backlinkProps;
-    
-    useEffect(() => {
-        setPageTitle();
-    }, [summaryTitle, summaryBanner ])    
-    
-    return  <>
-        {!summaryBanner && summaryContent && backlinkAction && <Button variant='backlink' onClick={backlinkAction}>{backlinkText}</Button> }
-        <MainWrapper>
-            { (summaryBanner && summaryBanner !== "") ?
-                    <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
-                        <h1 className='govuk-panel__title'> {summaryBanner} </h1>
-                    </div> 
-                    :
-                    <h1 className='govuk-heading-l'>
-                        {summaryTitle}
-                    </h1>
-            }
-            <div><ParsedHTML htmlString={summaryContent} /></div>
-        </MainWrapper>
+const SummaryPage = forwardRef<HTMLDivElement, any>((props, ref) => {
+  const { summaryTitle, summaryContent, summaryBanner, backlinkProps } = props;
+  const { backlinkAction, backlinkText } = backlinkProps;
+
+  useEffect(() => {
+    setPageTitle();
+  }, [summaryTitle, summaryBanner]);
+
+  return (
+    <>
+      {!summaryBanner && summaryContent && backlinkAction && (
+        <Button variant='backlink' onClick={backlinkAction}>
+          {backlinkText}
+        </Button>
+      )}
+      <MainWrapper>
+        <div ref={ref}>
+          {summaryBanner && summaryBanner !== '' ? (
+            <div className='govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-7'>
+              <h1 className='govuk-panel__title'>{summaryBanner}</h1>
+            </div>
+          ) : (
+            <h1 className='govuk-heading-l'>{summaryTitle}</h1>
+          )}
+          <div>
+            <ParsedHTML htmlString={summaryContent} />
+          </div>
+        </div>
+      </MainWrapper>
     </>
-}
+  );
+});
+
+export default SummaryPage;

--- a/src/samples/EducationStart/ClaimList.tsx
+++ b/src/samples/EducationStart/ClaimList.tsx
@@ -33,7 +33,8 @@ export default function ClaimsList(props) {
     });
   };
 
-  async function _rowClick(row: any) {
+  async function _rowClick(e, row: any) {
+    e.preventDefault();
     const { pzInsKey, pyAssignmentID } = row;
 
     const container = thePConn.getContainerName();
@@ -113,8 +114,8 @@ export default function ClaimsList(props) {
         <Button
           attributes={{ className: 'govuk-!-margin-top-4 govuk-!-margin-bottom-4' }}
           variant='secondary'
-          onClick={() => {
-            _rowClick(claimItem);
+          onClick={(e) => {
+            _rowClick(e, claimItem.rowDetails);
           }}
         >
           {claimItem.actionButton}

--- a/src/samples/EducationStart/ClaimList.tsx
+++ b/src/samples/EducationStart/ClaimList.tsx
@@ -37,7 +37,9 @@ export default function ClaimsList(props) {
     e.preventDefault();
     const { pzInsKey, pyAssignmentID } = row;
 
-    const container = thePConn.getContainerName();
+    // const container = thePConn.getContainerName();
+    const container = 'primary'; 
+
     const target = `${PCore.getConstants().APP.APP}/${container}`;
 
     if (rowClickAction === 'OpenAssignment') {
@@ -72,24 +74,27 @@ export default function ClaimsList(props) {
     return claimItem.children.map((child, index) => (
       <React.Fragment key={child?.firstName}>
         <dl className='govuk-summary-list govuk-!-margin-bottom-0'>
-          <div className='govuk-summary-list__row govuk-summary-list__row--no-border'>
-            <dt className='govuk-summary-list__key govuk-!-width-one-third govuk-!-padding-bottom-2'>
-              {t('YOUNG_PERSON_NAME')}
-            </dt>
-            <dd className='govuk-summary-list__value govuk-!-width-one-third govuk-!-padding-bottom-2'>
-              {child?.firstName} {child?.lastName}
-            </dd>
-            <dd className='govuk-summary-list__actions govuk-!-width-one-third govuk-!-padding-bottom-2'>
-              {/* If this is the first entry add the status */}
-              {index === 0 ? (
-                <strong className={`govuk-tag govuk-tag--${claimItem.status.tagColour}`}>
-                  {claimItem.status.text}
-                </strong>
-              ) : (
-                <span className='govuk-visually-hidden'>No action</span>
-              )}
-            </dd>
-          </div>
+          {(child?.firstName ||
+            child?.lastName) && (
+              <div className='govuk-summary-list__row govuk-summary-list__row--no-border'>
+                <dt className='govuk-summary-list__key govuk-!-width-one-third govuk-!-padding-bottom-2'>
+                  {t('YOUNG_PERSON_NAME')}
+                </dt>
+                <dd className='govuk-summary-list__value govuk-!-width-one-third govuk-!-padding-bottom-2'>
+                  {child?.firstName} {child?.lastName}
+                </dd>
+                <dd className='govuk-summary-list__actions govuk-!-width-one-third govuk-!-padding-bottom-2'>
+                  {/* If this is the first entry add the status */}
+                  {index === 0 ? (
+                    <strong className={`govuk-tag govuk-tag--${claimItem.status.tagColour}`}>
+                      {claimItem.status.text}
+                    </strong>
+                  ) : (
+                    <span className='govuk-visually-hidden'>No action</span>
+                  )}
+                </dd>
+              </div>
+            )}
           {child?.dob && (
             <div className='govuk-summary-list__row govuk-summary-list__row--no-border'>
               <dt className='govuk-summary-list__key govuk-!-width-one-third govuk-!-padding-bottom-2'>
@@ -108,13 +113,22 @@ export default function ClaimsList(props) {
             <dd className='govuk-summary-list__value govuk-!-width-one-third govuk-!-padding-bottom-2'>
               {claimItem.dateCreated}
             </dd>
+            {!child?.firstName && !child?.lastName && (
+              <dd className='govuk-summary-list__actions govuk-!-width-one-third'>
+                {!claimItem.childrenAdded && (
+                  <strong className={`govuk-tag govuk-tag--${claimItem.status.tagColour}`}>
+                    {claimItem.status.text}
+                  </strong>
+                )}
+              </dd>
+            )}
           </div>
         </dl>
 
         <Button
           attributes={{ className: 'govuk-!-margin-top-4 govuk-!-margin-bottom-4' }}
           variant='secondary'
-          onClick={(e) => {
+          onClick={e => {
             _rowClick(e, claimItem.rowDetails);
           }}
         >

--- a/src/samples/EducationStart/Landing.tsx
+++ b/src/samples/EducationStart/Landing.tsx
@@ -12,7 +12,9 @@ export default function Landing({
   handleStartCliam,
   assignmentPConn,
   showPortalBanner,
-  setShowLandingPage
+  setShowLandingPage,
+  showPortalPageDefault,
+  setShowPortalPageDefault
 }) {
   const [inProgressClaims, setInProgressClaims] = useState([]);
   const [submittedClaims, setSubmittedClaims] = useState([]);
@@ -30,7 +32,7 @@ export default function Landing({
     return JSON.parse(childrenJSON.slice(childrenJSON.indexOf(':') + 1));
   }
 
-    const statusMapping = status => {
+  const statusMapping = status => {
     switch (status) {
       case 'Open-InProgress':
         return { text: t('IN_PROGRESS'), tagColour: 'blue' };
@@ -61,6 +63,7 @@ export default function Landing({
           dateUpdated: item.pxUpdateDateTime,
           children: [],
           actionButton: buttonContent,
+          rowDetails: { pzInsKey: item.pzInsKey, pyAssignmentID: item.pyAssignmentID },
           status: statusMapping(item.pyStatusWork)
         };
 
@@ -101,7 +104,7 @@ export default function Landing({
       .finally(() => setLoadingSubmittedClaims(false));
   }
 
-  function fetchInProgressClaimsData(isSaveComeBackClicked = false) {
+  function fetchInProgressClaimsData() {
     let inProgressClaimsData: any = [];
     // @ts-ignore
     PCore.getDataPageUtils()
@@ -113,15 +116,6 @@ export default function Landing({
       })
       .finally(() => {
         setLoadingInProgressClaims(false);
-        if (isSaveComeBackClicked) {
-          // Here we are calling this close container because of the fact that above
-          // D_ClaimantWorkAssignmentChBCases API is getting excuted as last call but we want to make
-          // close container call as the very last one.
-          PCore.getContainerUtils().closeContainerItem(
-            PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
-            { skipDirtyCheck: true }
-          );
-        }
       });
   }
 
@@ -131,9 +125,10 @@ export default function Landing({
   }, []);
 
   return (
-    !(loadingInProgressClaims && loadingSubmittedClaims) && (
+    (!loadingInProgressClaims && !loadingSubmittedClaims) && (
       <>
-        {!showStartClaim && (inProgressClaims.length || submittedClaims.length) ? (
+        {showPortalPageDefault ||
+        (!showStartClaim && (inProgressClaims.length || submittedClaims.length)) ? (
           <PortalPage
             inProgressClaims={inProgressClaims}
             submittedClaims={submittedClaims}
@@ -141,6 +136,7 @@ export default function Landing({
             setShowStartClaim={setShowStartClaim}
             showPortalBanner={showPortalBanner}
             setShowLandingPage={setShowLandingPage}
+            setShowPortalPageDefault={setShowPortalPageDefault}
           />
         ) : (
           <StartClaim

--- a/src/samples/EducationStart/Landing.tsx
+++ b/src/samples/EducationStart/Landing.tsx
@@ -56,7 +56,6 @@ export default function Landing({
   function getClaims(data, buttonContent) {
     const claimsData = [];
     data.forEach(item => {
-      if (item.ClaimExtension?.Child?.pyFirstName !== null) {
         const claimItem = {
           claimRef: item.pyID,
           dateCreated: DateFormatter.Date(item.pxCreateDateTime, { format: 'DD MMM YYYY' }),
@@ -87,7 +86,6 @@ export default function Landing({
           });
         }
         claimsData.push(claimItem);
-      }
     });
     return claimsData;
   }

--- a/src/samples/EducationStart/PortalPage.tsx
+++ b/src/samples/EducationStart/PortalPage.tsx
@@ -13,13 +13,15 @@ export default function PortalPage(props) {
     submittedClaims,
     assignmentPConn,
     setShowLandingPage,
-    setShowStartClaim
+    setShowStartClaim,
+    setShowPortalPageDefault
   } = props;
   const { t } = useTranslation();
 
   function showStartClaim(e) {
     e.preventDefault();
     setShowStartClaim(true);
+    setShowPortalPageDefault(false);
   }
 
   useEffect(() => {

--- a/src/samples/EducationStart/PortalPage.tsx
+++ b/src/samples/EducationStart/PortalPage.tsx
@@ -85,7 +85,6 @@ export default function PortalPage(props) {
                 caseId={getClaimsCaseId()}
                 fieldType={t('SUBMITTED_DATE')}
                 setShowLandingPage={setShowLandingPage}
-
               />
             </div>
           </div>

--- a/src/samples/EducationStart/index.tsx
+++ b/src/samples/EducationStart/index.tsx
@@ -335,7 +335,9 @@ const EducationStartCase: FunctionComponent<any> = () => {
       );
     });
     settingTimer();
-    PCore.getStore().subscribe(() => staySignedIn(setShowTimeoutModal, '', null, true, false));
+    PCore.getStore().subscribe(() =>
+      staySignedIn(setShowTimeoutModal, '', null, false, true, currentDisplay === 'resolutionpage')
+    );
   });
 
   // And clean up

--- a/src/samples/EducationStart/index.tsx
+++ b/src/samples/EducationStart/index.tsx
@@ -275,7 +275,20 @@ const EducationStartCase: FunctionComponent<any> = () => {
 
   useEffect(() => {
     if (showPega && pCoreReady && startClaimClicked) {
-      PCore.getMashupApi().createCase('HMRC-ChB-Work-EducationStart', PCore.getConstants().APP.APP);
+      let startingFields = {};
+      startingFields = {
+        NotificationLanguage: sessionStorage.getItem('rsdk_locale')?.slice(0, 2) || 'en'
+      };
+
+      PCore.getMashupApi().createCase(
+        'HMRC-ChB-Work-EducationStart',
+        PCore.getConstants().APP.APP,
+        {
+          startingFields,
+          pageName: '',
+          channelName: ''
+        }
+      );
       requestAnimationFrame(removeHmrcLink); // TODO - To be removed with US-13518 implementation.
     }
   }, [pCoreReady, showPega, startClaimClicked]);

--- a/src/samples/EducationStart/index.tsx
+++ b/src/samples/EducationStart/index.tsx
@@ -177,6 +177,7 @@ const EducationStartCase: FunctionComponent<any> = () => {
     setCurrentDisplay('landingpage');
     setShowPortalBanner(showBanner);
     setAssignmentCancelled(false);
+    setStartClaimClicked(false);
   }
 
   useEffect(() => {

--- a/src/samples/EducationStart/index.tsx
+++ b/src/samples/EducationStart/index.tsx
@@ -371,7 +371,18 @@ const EducationStartCase: FunctionComponent<any> = () => {
     setPageTitle();
     return (
       <>
-        <AppHeader appname={t('EDUCATION_START')} />
+        <AppHeader
+          handleSignout={handleSignout}
+          appname={t('EDUCATION_START')}
+          hasLanguageToggle={showLanguageToggleState}
+          isPegaApp={showPega}
+          languageToggleCallback={toggleNotificationProcess(
+            { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
+            assignmentPConnect?.getDataObject()?.caseInfo ? assignmentPConnect : null
+          )}
+          betafeedbackurl={`${hmrcURL}contact/beta-feedback?service=claim-child-benefit-frontend&backUrl=/fill-online/claim-child-benefit/recently-claimed-child-benefit`}
+        />
+
         <div className='govuk-width-container'>
           <MainWrapper showPageNotWorkingLink={false}>
             <h1 className='govuk-heading-l'>Sorry, the service is unavailable</h1>

--- a/src/samples/EducationStart/index.tsx
+++ b/src/samples/EducationStart/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect, useContext } from 'react';
+import React, { FunctionComponent, useState, useEffect, useContext, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import Landing from './Landing';
 import setPageTitle, { registerServiceName } from '../../components/helpers/setPageTitleHelpers';
@@ -27,16 +27,16 @@ const EducationStartCase: FunctionComponent<any> = () => {
   const educationStartParam = 'claim-child-benefit';
   const claimsListApi = 'D_ClaimantWorkAssignmentEdStartCases';
 
+  const summaryPageRef = useRef<HTMLDivElement>(null);
+
   const [showLandingPage, setShowLandingPage] = useState<boolean>(true);
+  const [showPortalPageDefault, setShowPortalPageDefault] = useState<boolean>(false);
   const [startClaimClicked, setStartClaimClicked] = useState(false);
   const [shuttered, setShuttered] = useState(null);
-
   const [pCoreReady, setPCoreReady] = useState(false);
   const { showLanguageToggle } = useContext(AppContextEducation);
   const [showLanguageToggleState, setShowLanguageToggleState] = useState(showLanguageToggle);
-
   const setAuthType = useState('gg')[1];
-
   const [currentDisplay, setCurrentDisplay] = useState<
     | 'pegapage'
     | 'resolutionpage'
@@ -45,13 +45,11 @@ const EducationStartCase: FunctionComponent<any> = () => {
     | 'loading'
     | 'landingpage'
   >('pegapage');
-
   const [summaryPageContent, setSummaryPageContent] = useState<any>({
     content: null,
     title: null,
     banner: null
   });
-
   const [showTimeoutModal, setShowTimeoutModal] = useState(false);
   const [showSignoutModal, setShowSignoutModal] = useState(false);
   const [showPortalBanner, setShowPortalBanner] = useState(false);
@@ -89,11 +87,11 @@ const EducationStartCase: FunctionComponent<any> = () => {
     serviceParam: educationStartParam
   });
 
-  useEffect(()=>{
-    if(assignmentPConnect) {
+  useEffect(() => {
+    if (assignmentPConnect) {
       setPconnect(assignmentPConnect);
-    } 
-  },[assignmentPConnect])
+    }
+  }, [assignmentPConnect]);
 
   function handleSignout() {
     if (currentDisplay === 'pegapage') {
@@ -163,16 +161,19 @@ const EducationStartCase: FunctionComponent<any> = () => {
       requestAnimationFrame(removeHmrcLink);
     }
   }
+
   function closeContainer() {
-    PCore.getContainerUtils().closeContainerItem(
-      PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
-      { skipDirtyCheck: true }
-    );
-    setShowPega(false);
+    if (PCore.getContainerUtils().getActiveContainerItemName('app/primary')) {
+      PCore.getContainerUtils().closeContainerItem(
+        PCore.getContainerUtils().getActiveContainerItemContext('app/primary'),
+        { skipDirtyCheck: true }
+      );
+    }
   }
 
   function returnedToPortal(showBanner = false) {
     closeContainer();
+    setShowPega(false);
     setCurrentDisplay('landingpage');
     setShowPortalBanner(showBanner);
     setAssignmentCancelled(false);
@@ -187,22 +188,30 @@ const EducationStartCase: FunctionComponent<any> = () => {
   }, [assignmentCancelled]);
 
   useEffect(() => {
-    if (currentDisplay === 'resolutionpage') {
-      const homepage = document.getElementById('#homepage');
-      if (homepage) {
-        homepage.addEventListener('click', () => returnedToPortal(false));
+    function handleClick(e) {
+      e.preventDefault();
+      const targetId = e.target.id;
+      if (targetId === 'homepage') {
+        returnedToPortal(false);
+        setShowPortalPageDefault(true);
       }
-
-      return () => {
-        if (homepage) {
-          homepage.removeEventListener('click', () => returnedToPortal(false));
-        }
-      };
     }
-  }, [currentDisplay]);
+
+    const currentSummaryPageRef = summaryPageRef.current;
+    if (currentSummaryPageRef) {
+      currentSummaryPageRef.addEventListener('click', handleClick);
+    }
+    return () => {
+      if (currentSummaryPageRef) {
+        currentSummaryPageRef.removeEventListener('click', handleClick);
+      }
+    };
+  }, [summaryPageContent]);
 
   useEffect(() => {
-    if (showLandingPage && pCoreReady) {
+    if (shutterServicePage) {
+      setCurrentDisplay('shutterpage');
+    } else if (showLandingPage && pCoreReady) {
       setCurrentDisplay('landingpage');
     } else if (showPega) {
       setCurrentDisplay('pegapage');
@@ -246,8 +255,6 @@ const EducationStartCase: FunctionComponent<any> = () => {
             return false;
           });
       });
-    } else if (shutterServicePage) {
-      setCurrentDisplay('shutterpage');
     } else if (serviceNotAvailable) {
       setCurrentDisplay('servicenotavailable');
     } else {
@@ -349,7 +356,11 @@ const EducationStartCase: FunctionComponent<any> = () => {
   } else if (currentDisplay === 'servicenotavailable') {
     return (
       <>
-        <AppHeader appname={t('EDUCATION_START')} hasLanguageToggle={showLanguageToggleState} />
+        <AppHeader
+          appname={t('EDUCATION_START')}
+          hasLanguageToggle={showLanguageToggleState}
+          handleSignout={handleSignout}
+        />
         <div className='govuk-width-container'>
           <ServiceNotAvailable returnToPortalPage={returnToPortalPage} />
         </div>
@@ -421,12 +432,10 @@ const EducationStartCase: FunctionComponent<any> = () => {
           appname={t('EDUCATION_START')}
           hasLanguageToggle={showLanguageToggleState}
           isPegaApp={showPega}
-          languageToggleCallback= {
-            toggleNotificationProcess(
-          { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
-          assignmentPConnect?.getDataObject()?.caseInfo ? assignmentPConnect : null
-          ) 
-          }
+          languageToggleCallback={toggleNotificationProcess(
+            { en: 'SwitchLanguageToEnglish', cy: 'SwitchLanguageToWelsh' },
+            assignmentPConnect?.getDataObject()?.caseInfo ? assignmentPConnect : null
+          )}
           betafeedbackurl={`${hmrcURL}contact/beta-feedback?service=claim-child-benefit-frontend&backUrl=/fill-online/claim-child-benefit/recently-claimed-child-benefit`}
         />
         <div className='govuk-width-container'>
@@ -443,6 +452,8 @@ const EducationStartCase: FunctionComponent<any> = () => {
                   assignmentPConn={pConnect}
                   showPortalBanner={showPortalBanner}
                   setShowLandingPage={setShowLandingPage}
+                  showPortalPageDefault={showPortalPageDefault}
+                  setShowPortalPageDefault={setShowPortalPageDefault}
                 />
               )}
               {currentDisplay === 'resolutionpage' && (
@@ -451,6 +462,7 @@ const EducationStartCase: FunctionComponent<any> = () => {
                   summaryTitle={summaryPageContent?.Title}
                   summaryBanner={summaryPageContent?.Banner}
                   backlinkProps={{}}
+                  ref={summaryPageRef}
                 />
               )}
             </>


### PR DESCRIPTION
This PR consist Portal page preconditions - 
- Default call will load inprogress and submitted cases, if no case available then default to Start claim page
- If a claimant clicks on Save and come back later button in any stage of request, they will be redirected to portal page
- Portal page will then show a banner- We saved your progress and will store your information for 28 days
- If a claimant has submitted the claim successfully (US-12980 & US-13510) and clicks on Tell us about another young person staying in approved education or training, they will be redirected to portal page.
- Claimants whose journey has ended and clicks on: ‘You can tell us about another young person’ (Refer US-12974/14276/ 14244/ 14245-AC4)o Will reach portal page
- Claimants whose journey has ended and clicks on: ‘You can return to home page’ (US-13679/14415)o Will reach portal page

Also covers fix for BUG-9010