### PR TITLE
Bug 8947 - Static pages error message not in welsh when toggled 

### DIFF
--- a/src/components/helpers/hooks/useTranslatedStaticPageError.ts
+++ b/src/components/helpers/hooks/useTranslatedStaticPageError.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function useTranslatedStaticPageError(translationKey, lang, errorMsg) {
+  const { t } = useTranslation();
+  const [translatedError, setTranslatedError] = useState('');
+
+  useEffect(() => {
+    if (errorMsg.length > 0) {
+      setTranslatedError(t(translationKey));
+    }
+  }, [lang, errorMsg]);
+
+  return translatedError;
+}

--- a/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
+++ b/src/samples/StaticPages/AreYouSureToContinueWithoutSignIn/AreYouSureToContinueWithoutSignIn.tsx
@@ -10,12 +10,19 @@ import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import setPageTitle from '../../../components/helpers/setPageTitleHelpers';
 import { getSdkConfig } from '@pega/auth/lib/sdk-auth-manager';
+import useTranslatedStaticPageError from '../../../components/helpers/hooks/useTranslatedStaticPageError';
 
 export default function AreYouSureToContinueWithoutSignIn() {
   const [errorMsg, setErrorMsg] = useState('');
   const { t } = useTranslation();
   const history = useHistory();
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
+  const translatedError = useTranslatedStaticPageError(
+    'SELECT_YES_IF_YOU_WANT_TO_CONTINUE_WO_SIGN_IN',
+    lang,
+    errorMsg
+  );
+
   useEffect(() => {
     const setPageTitleInterval = setInterval(() => {
       clearInterval(setPageTitleInterval);
@@ -75,7 +82,7 @@ export default function AreYouSureToContinueWithoutSignIn() {
         />
         <MainWrapper>
           <StaticPageErrorSummary
-            errorSummary={errorMsg}
+            errorSummary={translatedError}
             linkHref='#areYouSureToContinueWoSignIn'
           />
           <form>
@@ -87,7 +94,7 @@ export default function AreYouSureToContinueWithoutSignIn() {
               options={radioOptions}
               label={t('ARE_YOU_SURE_YOU_WANT_TO_CONTINUE_WO_SIGN_IN')}
               legendIsHeading
-              errorText={errorMsg}
+              errorText={translatedError}
             ></RadioButtons>
             <button
               className='govuk-button'

--- a/src/samples/StaticPages/CheckOnClaim/index.tsx
+++ b/src/samples/StaticPages/CheckOnClaim/index.tsx
@@ -8,6 +8,7 @@ import Button from '../../../components/BaseComponents/Button/Button';
 import setPageTitle from '../../../components/helpers/setPageTitleHelpers';
 import RadioButtons from '../../../components/BaseComponents/RadioButtons/RadioButtons';
 import StaticPageErrorSummary from '../ErrorSummary';
+import useTranslatedStaticPageError from '../../../components/helpers/hooks/useTranslatedStaticPageError';
 
 export default function CheckOnClaim() {
   const { t } = useTranslation();
@@ -15,6 +16,11 @@ export default function CheckOnClaim() {
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
   const [errorMsg, setErrorMsg] = useState('');
   const errorHref = `#typeOfClaimCheck`;
+  const translatedError = useTranslatedStaticPageError(
+    'SELECT_CHILD_BENEFIT_SERVICE',
+    lang,
+    errorMsg
+  );
 
   useEffect(() => {
     const setPageTitleInterval = setInterval(() => {
@@ -68,7 +74,7 @@ export default function CheckOnClaim() {
           attributes={{ type: 'link' }}
         />
         <MainWrapper>
-          <StaticPageErrorSummary errorSummary={errorMsg} linkHref={errorHref} />
+          <StaticPageErrorSummary errorSummary={translatedError} linkHref={errorHref} />
           <form>
             <RadioButtons
               name='typeOfClaimCheck'
@@ -78,7 +84,7 @@ export default function CheckOnClaim() {
               options={radioOptions}
               label={t('HOW_DO_YOU_WANT_TO_CHECK_ON_YOUR_CLAIM')}
               legendIsHeading
-              errorText={errorMsg}
+              errorText={translatedError}
             ></RadioButtons>
             <button
               className='govuk-button'

--- a/src/samples/StaticPages/ChooseClaimService/index.tsx
+++ b/src/samples/StaticPages/ChooseClaimService/index.tsx
@@ -8,6 +8,7 @@ import RadioButtons from '../../../components/BaseComponents/RadioButtons/RadioB
 import '../../../../assets/css/appStyles.scss';
 import StaticPageErrorSummary from '../ErrorSummary';
 import setPageTitle from '../../../components/helpers/setPageTitleHelpers';
+import useTranslatedStaticPageError from '../../../components/helpers/hooks/useTranslatedStaticPageError';
 
 export default function RecentlyClaimedChildBenefit() {
   const { t } = useTranslation();
@@ -15,6 +16,12 @@ export default function RecentlyClaimedChildBenefit() {
   const [errorMsg, setErrorMsg] = useState('');
   const errorHref = `#serviceType`;
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
+
+  const translatedError = useTranslatedStaticPageError(
+    'SELECT_CHILD_BENEFIT_SERVICE',
+    lang,
+    errorMsg
+  );
 
   useEffect(() => {
     const setPageTitleTimeout = setTimeout(() => {
@@ -93,7 +100,7 @@ export default function RecentlyClaimedChildBenefit() {
       <AppHeader appname={t('CLAIM_CHILD_BENEFIT')} hasLanguageToggle isPegaApp={false} />
       <div className='govuk-width-container'>
         <MainWrapper>
-          <StaticPageErrorSummary errorSummary={errorMsg} linkHref={errorHref} />
+          <StaticPageErrorSummary errorSummary={translatedError} linkHref={errorHref} />
           <form>
             <RadioButtons
               name='serviceType'
@@ -103,7 +110,7 @@ export default function RecentlyClaimedChildBenefit() {
               options={radioOptions}
               label={t('WHICH_CHBS_DO_YOU_WANT_TO_USE')}
               legendIsHeading
-              errorText={errorMsg}
+              errorText={translatedError}
             ></RadioButtons>
             <button
               className='govuk-button'

--- a/src/samples/StaticPages/DoYouWantToSignIn/doYouWantToSignIn.tsx
+++ b/src/samples/StaticPages/DoYouWantToSignIn/doYouWantToSignIn.tsx
@@ -9,12 +9,19 @@ import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import StaticPageErrorSummary from '../ErrorSummary';
 import setPageTitle from '../../../components/helpers/setPageTitleHelpers';
+import useTranslatedStaticPageError from '../../../components/helpers/hooks/useTranslatedStaticPageError';
 
 export default function DoYouWantToSignIn() {
   const [errorMsg, setErrorMsg] = useState('');
   const { t } = useTranslation();
   const history = useHistory();
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
+  const translatedError = useTranslatedStaticPageError(
+    'SELECT_YES_IF_YOU_WANT_TO_SIGN_IN',
+    lang,
+    errorMsg
+  );
+
   useEffect(() => {
     const setPageTitleInterval = setInterval(() => {
       clearInterval(setPageTitleInterval);
@@ -71,7 +78,7 @@ export default function DoYouWantToSignIn() {
           attributes={{ type: 'link' }}
         />
         <MainWrapper>
-          <StaticPageErrorSummary errorSummary={errorMsg} linkHref='#doYouWantToSignIn' />
+          <StaticPageErrorSummary errorSummary={translatedError} linkHref='#doYouWantToSignIn' />
           <form>
             <RadioButtons
               name='doYouWantToSignIn'
@@ -81,7 +88,7 @@ export default function DoYouWantToSignIn() {
               options={radioOptions}
               hintText={hintText}
               legendIsHeading
-              errorText={errorMsg}
+              errorText={translatedError}
               label={t('DO_YOU_WANT_TO_SIGN_IN')}
             ></RadioButtons>
             <button


### PR DESCRIPTION
Have added a custom hook to handle the error translations on the static pages if the user toggles the language after the error appears.