### PR TITLE
US-13000-1 (Education Start - Customer- Welsh Translation- All screens)

### DIFF
--- a/src/components/override-sdk/field/RadioButtons/RadioButtons.tsx
+++ b/src/components/override-sdk/field/RadioButtons/RadioButtons.tsx
@@ -47,7 +47,7 @@ export default function RadioButtons(props) {
   configProperty = configProperty.startsWith('.') ? configProperty.substring(1) : configProperty;
 
   const metaData = Array.isArray(fieldMetadata)
-    ? fieldMetadata.filter(field => field?.classID === className)[0]
+    ? (fieldMetadata.filter(field => field?.classID === className)[0] || fieldMetadata.filter(field => field?.displayAs === 'pxRadioButtons')[0])
     : fieldMetadata;
   let displayName = metaData?.datasource?.propertyForDisplayText;
   displayName = displayName?.slice(displayName.lastIndexOf('.') + 1);


### PR DESCRIPTION
**US-13000-1 (Education Start - Customer- Welsh Translation- All screens)**

This fix is for in some scenario(at more than one datasource), if not matching classname check then else part is taking data source to get localreference logic for radiooption.

This fix will work for one chb page as well. 