### PR TITLE
Bug-8814 Paragraphs Welsh language toggle issue ( + General Translation bug fixes - assignment headings) 

### DIFF
--- a/src/components/AppComponents/LanguageToggle/index.tsx
+++ b/src/components/AppComponents/LanguageToggle/index.tsx
@@ -11,6 +11,7 @@ const LanguageToggle = props => {
   const { i18n } = useTranslation();
   let lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
   const [selectedLang, setSelectedLang] = useState(lang);
+  const [resourcebundles, setResourceBundles] = useState([]);
 
   const changeLanguage = e => {
     e.preventDefault();
@@ -28,7 +29,8 @@ const LanguageToggle = props => {
         PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
         '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE',
         '@BASECLASS!DATAPAGE!D_SCOPEDREFERENCEDATALISTBYTYPE',
-        'HMRC-CHB-WORK-CLAIM!CASE!CLAIM'
+        'HMRC-CHB-WORK-CLAIM!CASE!CLAIM',
+        ...resourcebundles
       ]);
       
       PCore.getPubSubUtils().publish('languageToggleTriggered', { language: lang, localeRef: [] });
@@ -39,7 +41,14 @@ const LanguageToggle = props => {
   };
 
   // Initialises language value in session storage, and for dayjs
-  useEffect(() => {
+  useEffect(() => {  
+    document.addEventListener('SdkConstellationReady', () => {
+      PCore.onPCoreReady(() => {
+        PCore.getPubSubUtils().subscribe(PCore.getConstants().PUB_SUB_EVENTS.EVENT_EXPRESS_LOCALACTION, (data) =>  {
+          setResourceBundles(data.submitResponse.uiResources.localeReferences);
+        })
+      })});
+
     if (!sessionStorage.getItem('rsdk_locale')) {
       sessionStorage.setItem('rsdk_locale', `en_GB`);
       dayjs.locale('en');

--- a/src/components/AppComponents/LanguageToggle/index.tsx
+++ b/src/components/AppComponents/LanguageToggle/index.tsx
@@ -23,15 +23,24 @@ const LanguageToggle = props => {
       setPageTitle();
     });
     if (typeof PCore !== 'undefined') {
-      PCore.getEnvironmentInfo().setLocale(`${lang}_GB`);
-      PCore.getLocaleUtils().resetLocaleStore();
-      PCore.getLocaleUtils().loadLocaleResources([
+      // Fetch Locale Reference names for data pages
+      const datapageKeys = Object.keys(PCore.getDataPageUtils().datastore);
+      const dataPageBundleNames = datapageKeys.map((dpageName)=> {
+        return `@BASECLASS!DATAPAGE!${dpageName.toUpperCase()}`
+      })
+      
+      const bundles = [
         PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
         '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE',
         '@BASECLASS!DATAPAGE!D_SCOPEDREFERENCEDATALISTBYTYPE',
         'HMRC-CHB-WORK-CLAIM!CASE!CLAIM',
-        ...resourcebundles
-      ]);
+      ]
+
+      bundles.push(...resourcebundles, ...dataPageBundleNames)
+
+      PCore.getEnvironmentInfo().setLocale(`${lang}_GB`);
+      PCore.getLocaleUtils().resetLocaleStore();
+      PCore.getLocaleUtils().loadLocaleResources(bundles);
       
       PCore.getPubSubUtils().publish('languageToggleTriggered', { language: lang, localeRef: [] });
     }

--- a/src/components/custom-constellation/template/HMRC_ODX_sectionBased/demo.stories.tsx
+++ b/src/components/custom-constellation/template/HMRC_ODX_sectionBased/demo.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-useless-fragment */
 // @ts-nocheck
 import { useState } from 'react';
 import { withKnobs } from '@storybook/addon-knobs';

--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -171,13 +171,7 @@ export default function AutoComplete(props: AutoCompleteProps) {
     ''
   );
 
-  useEffect(() => {
-    if (currentLang === 'CY') {
-      /* PCore.getLocaleUtils().loadLocaleResources([
-        `@BASECLASS!DATAPAGE!${datasource.toUpperCase()}`
-      ]); */
-    }
-
+  useEffect(() => {   
     if (!displayMode && listType !== 'associated') {
       getDataPage(datasource, parameters, context).then((results: any) => {
         const optionsData: Array<any> = [];

--- a/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
+++ b/src/components/override-sdk/field/AutoComplete/AutoComplete.tsx
@@ -173,9 +173,9 @@ export default function AutoComplete(props: AutoCompleteProps) {
 
   useEffect(() => {
     if (currentLang === 'CY') {
-      PCore.getLocaleUtils().loadLocaleResources([
+      /* PCore.getLocaleUtils().loadLocaleResources([
         `@BASECLASS!DATAPAGE!${datasource.toUpperCase()}`
-      ]);
+      ]); */
     }
 
     if (!displayMode && listType !== 'associated') {

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -211,7 +211,7 @@ export default function Assignment(props) {
             validatemessage =
               validatemessage +
               (validatemessage.length > 0 ? '. ' : '') +
-              localizedVal(removeRedundantString(element.message), 'Messages');
+              localizedVal(removeRedundantString(element.message), 'Messages', localeReference);
           });
         }
 
@@ -240,7 +240,7 @@ export default function Assignment(props) {
 
           acc.push({
             message: {
-              message: localizedVal(removeRedundantString(validatemessage)),
+              message: removeRedundantString(validatemessage),
               pageRef,
               fieldId,
               clearMessageProperty

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -55,7 +55,7 @@ export default function Assignment(props) {
     : SdkComponentMap.getPegaProvidedComponentMap()['AssignmentCard'];
 
   const actionsAPI = thePConn.getActionsApi();
-  const localizedVal = thePConn.getLocalizedValue; //PCore.getLocaleUtils().getLocaleValue;
+  const localizedVal = thePConn.getLocalizedValue;
   const localeCategory = 'Assignment';
   const localeReference = `${getPConnect().getCaseInfo().getClassName()}!CASE!${getPConnect()
     .getCaseInfo()
@@ -73,10 +73,8 @@ export default function Assignment(props) {
   const [errorSummary, setErrorSummary] = useState(false);
   const [errorMessages, setErrorMessages] = useState<Array<OrderedErrorMessage>>([]);
   const [serviceShutteredStatus, setServiceShutteredStatus] = useState(serviceShuttered);
-  const [header, setHeader] = useState('');
 
   const lang = sessionStorage.getItem('rsdk_locale')?.substring(0, 2) || 'en';
-  const [selectedLang, setSelectedLang] = useState(lang);
 
   const [hasAutoCompleteError, setHasAutoCompleteError] = useState('');
 
@@ -154,13 +152,7 @@ export default function Assignment(props) {
   if (caseInfo?.assignments?.length > 0) {
     containerName = caseInfo.assignments[0].name;
   }
-
-  const headerLocaleLocation = PCore.getStoreValue('localeReference', '', 'app');
-
-  PCore.getPubSubUtils().subscribe('languageToggleTriggered', langreference => {
-    setSelectedLang(langreference?.language);
-  });
-
+ 
   useEffect(() => {
     if (children && children.length > 0) {
       const oWorkItem = children[0].props.getPConnect();

--- a/src/components/override-sdk/infra/Assignment/Assignment.tsx
+++ b/src/components/override-sdk/infra/Assignment/Assignment.tsx
@@ -55,7 +55,7 @@ export default function Assignment(props) {
     : SdkComponentMap.getPegaProvidedComponentMap()['AssignmentCard'];
 
   const actionsAPI = thePConn.getActionsApi();
-  const localizedVal = PCore.getLocaleUtils().getLocaleValue;
+  const localizedVal = thePConn.getLocalizedValue;//PCore.getLocaleUtils().getLocaleValue;
   const localeCategory = 'Assignment';
   const localeReference = `${getPConnect().getCaseInfo().getClassName()}!CASE!${getPConnect()
     .getCaseInfo()
@@ -161,12 +161,7 @@ export default function Assignment(props) {
     setSelectedLang(langreference?.language);
   });
 
-  useEffect(() => {
-    setTimeout(() => {
-      setHeader(localizedVal(containerName, 'Assignment', '@BASECLASS!GENERIC!PYGENERICFIELDS'));
-    }, 60);
-
-  }, [headerLocaleLocation, containerName, selectedLang]);
+  
 
   useEffect(() => {
     if (children && children.length > 0) {
@@ -531,7 +526,7 @@ export default function Assignment(props) {
             {(!isOnlyFieldDetails.isOnlyField ||
               containerName?.toLowerCase().includes('check your answer') ||
               containerName?.toLowerCase().includes('declaration')) && (
-              <h1 className='govuk-heading-l'>{header}</h1>
+              <h1 className='govuk-heading-l'>{localizedVal(containerName, 'Assignment', '@BASECLASS!GENERIC!PYGENERICFIELDS')}</h1>
             )}
             {shouldRemoveFormTag ? renderAssignmentCard() : <form>{renderAssignmentCard()}</form>}
             <a

--- a/src/components/override-sdk/infra/View/View.tsx
+++ b/src/components/override-sdk/infra/View/View.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 // import { FieldGroup } from "@pega/cosmos-react-core";
 // import { LazyMap as LazyComponentMap } from "../../components_map";
@@ -26,20 +26,9 @@ const NO_HEADER_TEMPLATES = [
   'Confirmation'
 ];
 
-declare const PCore: any;
 export default function View(props) {
   const { children, template, getPConnect, mode, visibility, name: pageName } = props;
   let { label, showLabel = false } = props;
-
-  // call the locale reference api when we toggle the languge from English to Welsh
-  useEffect(() => {
-    PCore.getPubSubUtils().subscribe('languageToggleTriggered', locale => {
-      if (!locale.localeRef.includes(props.localeReference)) {
-        // locale.localeRef.push(props.localeReference);
-        // PCore.getLocaleUtils().loadLocaleResources([props.localeReference]);
-      }
-    });
-  }, []);
 
   // Get the inherited props from the parent to determine label settings. For 8.6, this is only for embedded data form views
   // Putting this logic here instead of copy/paste in every Form template index.js

--- a/src/components/override-sdk/infra/View/View.tsx
+++ b/src/components/override-sdk/infra/View/View.tsx
@@ -35,8 +35,8 @@ export default function View(props) {
   useEffect(() => {
     PCore.getPubSubUtils().subscribe('languageToggleTriggered', locale => {
       if (!locale.localeRef.includes(props.localeReference)) {
-        locale.localeRef.push(props.localeReference);
-        PCore.getLocaleUtils().loadLocaleResources([props.localeReference]);
+        // locale.localeRef.push(props.localeReference);
+        // PCore.getLocaleUtils().loadLocaleResources([props.localeReference]);
       }
     });
   }, []);

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -34,7 +34,7 @@ export default function DefaultForm(props) {
   // defaultForm kids
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
   let instructionText =
-    props.instructions === 'none' || props.instructions === null ? '' : props.instructions;
+    props.instructions === 'none' || props.instructions === null ? '' : getPConnect().getLocalizedValue(props.instructions);
   // If the parent Default Form has instruction text passed through, append it here so that it is not
   // lost in nested default forms
   if (passedThroughInstructionText) {

--- a/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
+++ b/src/components/override-sdk/template/DefaultForm/DefaultForm.tsx
@@ -34,7 +34,7 @@ export default function DefaultForm(props) {
   // defaultForm kids
   const arChildren = getPConnect().getChildren()[0].getPConnect().getChildren();
   let instructionText =
-    props.instructions === 'none' || props.instructions === null ? '' : getPConnect().getLocalizedValue(props.instructions);
+    props.instructions === 'none' || !props.instructions ? '' : getPConnect().getLocalizedValue(props.instructions);
   // If the parent Default Form has instruction text passed through, append it here so that it is not
   // lost in nested default forms
   if (passedThroughInstructionText) {

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -462,7 +462,6 @@ export default function ChildBenefitsClaim() {
           initTimeout(setShowTimeoutModal);
         });
 
-      // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
       
       initialRender(renderObj);

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -464,11 +464,11 @@ export default function ChildBenefitsClaim() {
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-      PCore.getLocaleUtils().resetLocaleStore();
-      PCore.getLocaleUtils().loadLocaleResources([
+      // PCore.getLocaleUtils().resetLocaleStore();
+      /* PCore.getLocaleUtils().loadLocaleResources([
         PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
         '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-      ]);
+      ]); */
       initialRender(renderObj);
 
       operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/ChildBenefitsClaim/index.tsx
+++ b/src/samples/ChildBenefitsClaim/index.tsx
@@ -464,11 +464,7 @@ export default function ChildBenefitsClaim() {
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-      // PCore.getLocaleUtils().resetLocaleStore();
-      /* PCore.getLocaleUtils().loadLocaleResources([
-        PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
-        '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-      ]); */
+      
       initialRender(renderObj);
 
       operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/EducationStart/reuseables/PegaSetup.tsx
+++ b/src/samples/EducationStart/reuseables/PegaSetup.tsx
@@ -314,11 +314,7 @@ export function startMashup(
 
     // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
     PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-    // PCore.getLocaleUtils().resetLocaleStore();
-    /* PCore.getLocaleUtils().loadLocaleResources([
-      PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
-      '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-    ]); */
+    
     initialRender(renderObj, setAssignmentPConnect, _AppContextValues);
 
     // PM!! operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/EducationStart/reuseables/PegaSetup.tsx
+++ b/src/samples/EducationStart/reuseables/PegaSetup.tsx
@@ -314,11 +314,11 @@ export function startMashup(
 
     // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
     PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-    PCore.getLocaleUtils().resetLocaleStore();
-    PCore.getLocaleUtils().loadLocaleResources([
+    // PCore.getLocaleUtils().resetLocaleStore();
+    /* PCore.getLocaleUtils().loadLocaleResources([
       PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
       '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-    ]);
+    ]); */
     initialRender(renderObj, setAssignmentPConnect, _AppContextValues);
 
     // PM!! operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/EducationStart/reuseables/PegaSetup.tsx
+++ b/src/samples/EducationStart/reuseables/PegaSetup.tsx
@@ -317,8 +317,6 @@ export function startMashup(
     
     initialRender(renderObj, setAssignmentPConnect, _AppContextValues);
 
-    // PM!! operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();
-
     /* Functionality to set the device id in the header for use in CIP.
       Device id is unique and will be stored on the user device / browser cookie */
     const COOKIE_PEGAODXDI = 'pegaodxdi';
@@ -337,17 +335,7 @@ export function startMashup(
         setCookie(COOKIE_PEGAODXDI, deviceID, 3650);
         PCore.getRestClient().getHeaderProcessor().registerHeader('deviceid', deviceID);
       });
-    }
-
-    // PM!! setLoadingSubmittedClaims(true);
-    // @ts-ignore
-    /* PCore.getDataPageUtils()
-        .getDataAsync('D_ClaimantSubmittedChBCases', 'root', { OperatorId: operatorId })
-        .then(resp => {
-          setSubmittedClaims(resp.data.slice(0, 10));
-        })
-        .finally(() => setLoadingSubmittedClaims(false));
-      fetchInProgressClaimsData(); */
+    }    
   });
 
   // Initialize the SdkComponentMap (local and pega-provided)

--- a/src/samples/HighIncomeCase/reuseables/PegaSetup.tsx
+++ b/src/samples/HighIncomeCase/reuseables/PegaSetup.tsx
@@ -258,13 +258,8 @@ export function startMashup(
         });
         */
 
-    // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
     PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-    /* PCore.getLocaleUtils().resetLocaleStore();
-    PCore.getLocaleUtils().loadLocaleResources([
-      PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
-      '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-    ]); */
+    
     initialRender(renderObj, setAssignmentPConnect, _AppContextValues);
 
     // PM!! operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/HighIncomeCase/reuseables/PegaSetup.tsx
+++ b/src/samples/HighIncomeCase/reuseables/PegaSetup.tsx
@@ -260,11 +260,11 @@ export function startMashup(
 
     // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
     PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-    PCore.getLocaleUtils().resetLocaleStore();
+    /* PCore.getLocaleUtils().resetLocaleStore();
     PCore.getLocaleUtils().loadLocaleResources([
       PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
       '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-    ]);
+    ]); */
     initialRender(renderObj, setAssignmentPConnect, _AppContextValues);
 
     // PM!! operatorId = PCore.getEnvironmentInfo().getOperatorIdentifier();

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -363,11 +363,11 @@ export default function UnAuthChildBenefitsClaim() {
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-      PCore.getLocaleUtils().resetLocaleStore();
+      /* PCore.getLocaleUtils().resetLocaleStore();
       PCore.getLocaleUtils().loadLocaleResources([
         PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
         '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-      ]);
+      ]); */
       initialRender(renderObj);
 
       /* Functionality to set the device id in the header for use in CIP.

--- a/src/samples/UnAuthChildBenefitsClaim/index.tsx
+++ b/src/samples/UnAuthChildBenefitsClaim/index.tsx
@@ -363,11 +363,7 @@ export default function UnAuthChildBenefitsClaim() {
 
       // TODO : Consider refactoring 'en_GB' reference as this may need to be set elsewhere
       PCore.getEnvironmentInfo().setLocale(sessionStorage.getItem('rsdk_locale') || 'en_GB');
-      /* PCore.getLocaleUtils().resetLocaleStore();
-      PCore.getLocaleUtils().loadLocaleResources([
-        PCore.getLocaleUtils().GENERIC_BUNDLE_KEY,
-        '@BASECLASS!DATAPAGE!D_LISTREFERENCEDATABYTYPE'
-      ]); */
+      
       initialRender(renderObj);
 
       /* Functionality to set the device id in the header for use in CIP.


### PR DESCRIPTION
Extends Language Toggle functionality to store list of localeResources for each page as we navigate through a claim to try to ensure that all required bundles are loaded and used when toggling language

Updates Assignment and Default form component to use the Pconnect localization call rather than PCore localization call as this appears to respond 'better' to locale resource loading (avoiding issue we have sometimes seen where localeStore was not updated/populated at time of PCore localisation call.
This has allowed a simplified Assignment Heading logic, simply calling localisation inline.

Finally, have also updated error message localisation in Assignment component to fix issue with missing localeReference due to new localisation call.

Also removes locale resource load calls from throughout the app as everything should be loaded correctly via LanguageToggle component.