### PR TITLE
US-16647 - Proof Entitlement getChBEntitlment DPage no longer needs NINO parameter

### DIFF
--- a/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
+++ b/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
@@ -71,9 +71,7 @@ export default function ProofOfEntitlement() {
           }
         });
         PCore.getDataPageUtils()
-          .getPageDataAsync('D_GetChBEntitlement', 'root', {
-            NINO: PCore.getEnvironmentInfo().getOperatorIdentifier()
-          })
+          .getPageDataAsync('D_GetChBEntitlement', 'root')
           .then(result => {
             // If no claimant data in response, assume no award (or api error)
             if (result.IsAPIError) {


### PR DESCRIPTION
Updated requirements for Proof of Entitlement service no longer require NINO to be passed from front end as parameter to the getEntitlement datapage, so removing the passing of this parameter from the getDPage api call.