### PR TITLE
US-16776-1: display POE details for up to 5 years

### DIFF
--- a/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
+++ b/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
@@ -77,8 +77,15 @@ export default function ProofOfEntitlement() {
             if (result.IsAPIError) {
               setShowProblemWithService(true);
             } else if (!result.HasAward) {
-              setShowNoAward(true);
+              if (result.canAccess) {
+                // Award can still be viewed for 5 years after end date
+                setEntitlementData(result);
+              } else {
+                // Award ended over 5 years ago
+                setShowNoAward(true);
+              }
             } else {
+              // User has active child benefit
               setEntitlementData(result);
             }
             setPageContentReady(true);


### PR DESCRIPTION
Data page returns 2 flags: hasAward and hasAccess.

hasAward is true IF the user has an active child benefit awarded and false if the award date is in the past.

hasAccess is true IF the end date is within 5 years of today and false if the end date is more than 5 years ago.

So using these flags we should show the entitlement if:
- User has an active child benefit
- If a User has had an active award in the last 5 years

Else the user should see this page:
![image](https://github.com/user-attachments/assets/04fd9439-ded4-434c-8203-42f8fdf32b4e)
 