### PR TITLE
US-9595: wrap loading page with main

### DIFF
--- a/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
+++ b/src/samples/ProofOfEntitlement/ProofOfEntitlement.tsx
@@ -271,7 +271,11 @@ export default function ProofOfEntitlement() {
             <br />
           </MainWrapper>
         </div>
-      )) || <LoadingSpinner bottomText={t('LOADING')} size='30px' />}
+      )) || (
+        <main className='govuk-main-wrapper govuk-main-wrapper--l' role='main' id='main-content'>
+          <LoadingSpinner bottomText={t('LOADING')} size='30px' />
+        </main>
+      )}
       <AppFooter />
     </>
   );


### PR DESCRIPTION
<img width="814" alt="main content" src="https://github.com/user-attachments/assets/18600e0c-7f12-4ed3-adc9-69837e509c72">
We have wrapped the loading page in a Main.

The skip to content accessible link works correctly too