### PR TITLE
BUG-9747: set the logo to not a link when the high contrast mode is on

### DIFF
--- a/assets/css/print.scss
+++ b/assets/css/print.scss
@@ -7,6 +7,12 @@
     margin: 80px 50px 50px;
   }
 
+  @media (forced-colors: active) {
+    .govuk-header__logotype {
+      color: currentColor;
+    }
+  }
+
   .print-only {
     display: block;
   }


### PR DESCRIPTION
When in high contrast mode, users are seeing yellow logos which is not an accessible colour. There is no change when the high contrast is off.

## Before (high contrast mode on)
<img width="956" alt="Before_High_contrast_On" src="https://github.com/user-attachments/assets/b2f7ac0e-7a1d-4582-a254-ce3b734cb4db">


## After (high contrast mode on)
<img width="953" alt="Fix_High_Contrast_mode_on" src="https://github.com/user-attachments/assets/e148bf63-e676-4e7d-ab0a-8a1327a79275">
